### PR TITLE
bud create fixes and improvements

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -39,7 +39,6 @@ func parse(args []string) error {
 	{ // $ bud create <app>
 		cmd := &create.Command{Bud: bud}
 		cli := cli.Command("create", "create a new project")
-		cli.Flag("link", "link for development").Bool(&cmd.Link).Default(false)
 		cli.Arg("dir").String(&cmd.Dir)
 		cli.Run(cmd.Run)
 	}

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -66,7 +66,6 @@ func (c *Command) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(dir, "link", "livebud", filepath.Join(budDir, "livebud"))
 		cmd := exec.CommandContext(ctx, npm, "link", "--loglevel=error", "livebud", filepath.Join(budDir, "livebud"))
 		cmd.Dir = dir
 		cmd.Stderr = os.Stderr

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -10,21 +10,24 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/livebud/bud/internal/command"
+	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/package/gomod"
 )
 
 type Command struct {
-	Bud  *command.Bud
-	Dir  string
-	Link bool
+	Bud *command.Bud
+	Dir string
 }
 
 func (c *Command) Run(ctx context.Context) error {
-	if _, err := os.Stat(c.Dir); nil == err {
-		return fmt.Errorf("%s already exists", c.Dir)
+	dir := filepath.Join(c.Bud.Dir, c.Dir)
+	if _, err := os.Stat(dir); nil == err {
+		return fmt.Errorf("%s already exists", dir)
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
@@ -33,30 +36,39 @@ func (c *Command) Run(ctx context.Context) error {
 		return err
 	}
 	eg, ctx2 := errgroup.WithContext(ctx)
-	eg.Go(func() error { return c.generatePackageJSON(ctx2, tmpDir, filepath.Base(c.Dir)) })
+	eg.Go(func() error { return c.generatePackageJSON(ctx2, tmpDir, filepath.Base(dir)) })
 	eg.Go(func() error { return c.generateGitIgnore(ctx2, tmpDir) })
 	eg.Go(func() error { return c.generateGoMod(ctx2, tmpDir) })
 	if err := eg.Wait(); err != nil {
 		return err
 	}
 	// Create the project directory
-	if err := os.MkdirAll(filepath.Dir(c.Dir), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dir), 0755); err != nil {
 		return err
 	}
 	// Move the temporary build path to the project directory
-	if err := os.Rename(tmpDir, c.Dir); err != nil {
+	if err := os.Rename(tmpDir, dir); err != nil {
 		return err
 	}
 	// TODO: clean this mess up.
-	// It's breaking out of the packagejson.go file, but moving symlinks doesn't
-	// seem to work.
-	if c.Link {
+	// It's breaking out of the packagejson.go file, but moving symlinks via
+	// os.Rename doesn't seem to work.
+	if version.Bud == "latest" {
 		npm, err := exec.LookPath("npm")
 		if err != nil {
 			return err
 		}
-		cmd := exec.CommandContext(ctx, npm, "link", "--loglevel=error", "livebud")
-		cmd.Dir = c.Dir
+		currentDir, err := dirname()
+		if err != nil {
+			return err
+		}
+		budDir, err := gomod.Absolute(currentDir)
+		if err != nil {
+			return err
+		}
+		fmt.Println(dir, "link", "livebud", filepath.Join(budDir, "livebud"))
+		cmd := exec.CommandContext(ctx, npm, "link", "--loglevel=error", "livebud", filepath.Join(budDir, "livebud"))
+		cmd.Dir = dir
 		cmd.Stderr = os.Stderr
 		cmd.Env = []string{
 			"HOME=" + os.Getenv("HOME"),
@@ -68,4 +80,13 @@ func (c *Command) Run(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// dirname gets the directory of this file
+func dirname() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("unable to get the current filename")
+	}
+	return filepath.Dir(filename), nil
 }

--- a/internal/command/create/gomod.go
+++ b/internal/command/create/gomod.go
@@ -52,15 +52,23 @@ func (c *Command) generateGoMod(ctx context.Context, dir string) error {
 		}
 	}
 	// Get the Go version
-	state.Version = strings.TrimPrefix(runtime.Version(), "go")
+	state.Version = strings.TrimPrefix(goVersion(runtime.Version()), "go")
 	// Add the required dependencies
-	state.Requires = []*Require{
-		{
-			Import:  "github.com/livebud/bud",
-			Version: "v" + version.Bud,
-		},
-	}
-	if c.Link {
+	if version.Bud != "latest" {
+		state.Requires = []*Require{
+			{
+				Import:  "github.com/livebud/bud",
+				Version: "v" + version.Bud,
+			},
+		}
+	} else {
+		// Link to local copy
+		state.Requires = []*Require{
+			{
+				Import:  "github.com/livebud/bud",
+				Version: "v0.0.0",
+			},
+		}
 		budModule, err := gomod.Find(wd)
 		if err != nil {
 			return err
@@ -80,4 +88,17 @@ func (c *Command) generateGoMod(ctx context.Context, dir string) error {
 		return err
 	}
 	return nil
+}
+
+// Version can be
+func goVersion(version string) string {
+	parts := strings.SplitN(version, ".", 3)
+	switch len(parts) {
+	case 1:
+		return parts[0] + ".0"
+	case 2:
+		return strings.Join(parts, ".")
+	default:
+		return strings.Join(parts[0:2], ".")
+	}
 }

--- a/internal/command/create/gomod_test.go
+++ b/internal/command/create/gomod_test.go
@@ -1,0 +1,16 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestGoVersion(t *testing.T) {
+	// TODO: does test if test dependencies end up in the final binary if we
+	// aren't using the package *_test
+	is := is.New(t)
+	is.Equal(goVersion("1.18.1"), "1.18")
+	is.Equal(goVersion("1.18"), "1.18")
+	is.Equal(goVersion("1"), "1.0")
+}

--- a/livebud/package.json
+++ b/livebud/package.json
@@ -1,7 +1,6 @@
 {
   "name": "livebud",
   "description": "JS Runtime for Bud",
-  "version": "main",
   "private": true,
   "type": "module",
   "keywords": [

--- a/livebud/package.json
+++ b/livebud/package.json
@@ -1,6 +1,7 @@
 {
   "name": "livebud",
   "description": "JS Runtime for Bud",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Changes:

- Fix `bud create` when running minor versions like `go 1.18.1`
- Improves `bud create` in development to automatically link against local packages