### PR TITLE
Add --trimpath to go tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ go.generate:
 
 # TODO: add -race back in
 go.test:
-	@ go test --failfast --timeout=20m $(GO_SOURCE)
+	@ go test --trimpath --failfast --timeout=20m $(GO_SOURCE)
 
 go.vet:
 	@ go vet $(GO_SOURCE)

--- a/package/gomod/mod_test.go
+++ b/package/gomod/mod_test.go
@@ -2,7 +2,6 @@ package gomod_test
 
 import (
 	"errors"
-	"go/build"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -118,8 +117,7 @@ func TestResolveStdDirectory(t *testing.T) {
 	is.NoErr(err)
 	dir, err := module.ResolveDirectory("net/http")
 	is.NoErr(err)
-	expected := filepath.Join(build.Default.GOROOT, "src", "net", "http")
-	is.Equal(dir, expected)
+	is.True(filepath.IsAbs(dir))
 }
 
 func TestResolveImport(t *testing.T) {

--- a/package/gomod/module.go
+++ b/package/gomod/module.go
@@ -106,7 +106,12 @@ func (m *Module) IsLocal(importPath string) bool {
 func (m *Module) ResolveDirectoryIn(localFS fs.FS, importPath string) (directory string, err error) {
 	// Handle standard library
 	if gois.StdLib(importPath) {
-		return filepath.Join(stdDir, importPath), nil
+		absdir := filepath.Join(stdDir, importPath)
+		// Ensure the resolved directory exists.
+		if _, err := os.Stat(absdir); err != nil {
+			return "", fmt.Errorf("mod: unable to resolve directory for replaced import path %q: %w", importPath, err)
+		}
+		return absdir, nil
 	}
 	// Handle local packages
 	modulePath := m.Import()


### PR DESCRIPTION
This is a follow-up from #2. The tests should have caught this issue, so I've updated the tests to catch this next time.