### PR TITLE
Fix for install URL to use Github link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Bud ships as a single binary that runs on Linux and Mac. You can follow along fo
 The easiest way to get started is by copying and pasting the command below in your terminal:
 
 ```diff
-$ curl -sf livebud.com/install | sh
+$ curl -sf https://raw.githubusercontent.com/livebud/bud/main/install.sh | sh
 ```
 
 This script will download the right binary for your operating system and move the binary to the right location in your `$PATH`.


### PR DESCRIPTION
Current DNS is not resolving for the install link. Also having the url point to the file on Github is a bit more confidence inspiring. You can easily go look to see what is in the file without downloading it.

PS this project looks amazing! Excited to build on this.