### PR TITLE
internal/gotemplate: format (gofmt) on Generate

### DIFF
--- a/internal/gotemplate/gotemplate.go
+++ b/internal/gotemplate/gotemplate.go
@@ -2,6 +2,7 @@ package gotemplate
 
 import (
 	"bytes"
+	"go/format"
 	"text/template"
 )
 
@@ -37,6 +38,9 @@ func (t *gotemplate) Generate(state interface{}) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	if err := t.tpl.Execute(buf, state); err != nil {
 		return nil, err
+	}
+	if val, err := format.Source(buf.Bytes()); err == nil {
+		return val, nil
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/gotemplate/gotemplate_test.go
+++ b/internal/gotemplate/gotemplate_test.go
@@ -1,0 +1,37 @@
+package gotemplate_test
+
+import (
+	"testing"
+
+	"github.com/livebud/bud/internal/gotemplate"
+	"github.com/matryer/is"
+)
+
+func TestGenerateGoFile(t *testing.T) {
+	is := is.New(t)
+	template := `package main
+
+	func main()  {
+		  println("{{ .name }}")
+}`
+	expect := `package main
+
+func main() {
+	println("jason")
+}
+`
+	generator := gotemplate.MustParse("test.gotext", template)
+	b, err := generator.Generate(map[string]string{"name": "jason"})
+	is.NoErr(err)
+	is.Equal(string(b), expect)
+}
+
+func TestGenerateFreeText(t *testing.T) {
+	is := is.New(t)
+	template := `Hi {{ .name }}`
+	expect := `Hi Kim`
+	generator := gotemplate.MustParse("test.gotext", template)
+	b, err := generator.Generate(map[string]string{"name": "Kim"})
+	is.NoErr(err)
+	is.Equal(string(b), expect)
+}


### PR DESCRIPTION
This _make sure_ that generate Go files are formatted with [gofmt](https://pkg.go.dev/go/format#Source)

<img width="325" alt="image" src="https://user-images.githubusercontent.com/14269809/168408804-aaba71a8-5ba7-46bd-aedb-640a2206c4da.png"> 
I haven't look at the other files