### PR TITLE
fix: move the prompt out of the routines

### DIFF
--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -35,7 +35,10 @@ func (c *Command) Run(ctx context.Context) error {
 		return err
 	}
 
-	c.generateGoMod(ctx, tmpDir)
+	err = c.generateGoMod(ctx, tmpDir)
+	if err != nil {
+		return err
+	}
 
 	eg, ctx2 := errgroup.WithContext(ctx)
 	eg.Go(func() error { return c.generateGitIgnore(ctx2, tmpDir) })

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -34,10 +34,12 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	c.generateGoMod(ctx, tmpDir)
+
 	eg, ctx2 := errgroup.WithContext(ctx)
-	eg.Go(func() error { return c.generatePackageJSON(ctx2, tmpDir, filepath.Base(dir)) })
 	eg.Go(func() error { return c.generateGitIgnore(ctx2, tmpDir) })
-	eg.Go(func() error { return c.generateGoMod(ctx2, tmpDir) })
+	eg.Go(func() error { return c.generatePackageJSON(ctx2, tmpDir, filepath.Base(dir)) })
 	if err := eg.Wait(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Current Behavior 
Both npm output and the prompt for the app modules is overlapped by each other

## Changes by the PR 
Use the original context while prioritizing the prompt and then running the other stuff in the derived context and routines.

