### PR TITLE
fix: installing binary with write permissions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,10 +47,10 @@ execute() {
   (cd "${tmp_dir}" && untar "${TARBALL}")
 
   if [ -w "$BINDIR" ]; then
-  log_info "Installing $out to $prefix"
     install -d "${BINDIR}"
     install "${tmp_dir}/${NAME}/${BINARY}" "${BINDIR}/"
   else
+    echo "Elevated permissions required to install the binary"
     sudo install -d "${BINDIR}"
     sudo install "${tmp_dir}/${NAME}/${BINARY}" "${BINDIR}/"
   fi

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,14 @@ execute() {
 
   (cd "${tmp_dir}" && untar "${TARBALL}")
 
+  # we check if the directory we plan to store the binary in is actually writable by
+  # the current user. If not , we request for sudo permissions  
+  # this is done by -w in the if condition 
+  # -w - write 
+  # -r - read 
+  # -x - execution 
+  # -x is avoided here since the assumption is that the user will install 
+  # the binary in a directory already in the PATH env var 
   if [ -w "$BINDIR" ]; then
     install -d "${BINDIR}"
     install "${tmp_dir}/${NAME}/${BINARY}" "${BINDIR}/"

--- a/install.sh
+++ b/install.sh
@@ -45,10 +45,19 @@ execute() {
   hash_sha256_verify "${tmp_dir}/${TARBALL}" "${tmp_dir}/${CHECKSUM}"
 
   (cd "${tmp_dir}" && untar "${TARBALL}")
-  install -d "${BINDIR}"
-  install "${tmp_dir}/${NAME}/${BINARY}" "${BINDIR}/"
+
+  if [ -w "$BINDIR" ]; then
+  log_info "Installing $out to $prefix"
+    install -d "${BINDIR}"
+    install "${tmp_dir}/${NAME}/${BINARY}" "${BINDIR}/"
+  else
+    sudo install -d "${BINDIR}"
+    sudo install "${tmp_dir}/${NAME}/${BINARY}" "${BINDIR}/"
+  fi
+  
   echo "$PREFIX: installed as ${BINDIR}/${BINARY}"
 }
+
 is_supported_platform() {
   platform=$1
   found=1


### PR DESCRIPTION
## Current Behaviour
If the binary folder is not owned by the user then it fails to install it 

## After Merge 
The write permissions of the folder are checked before doing any installing
and elevated permissions are requested for it