### PR TITLE
ignore interrupt and killed errors when closing a process

### DIFF
--- a/example/basic/controller/controller.go
+++ b/example/basic/controller/controller.go
@@ -4,7 +4,7 @@ type Controller struct {
 }
 
 func (c *Controller) Index() string {
-	return "hello world"
+	return "hello world."
 }
 
 func (c *Controller) Show(id string) string {

--- a/package/exe/command.go
+++ b/package/exe/command.go
@@ -26,7 +26,7 @@ func (c *Cmd) Close() error {
 		}
 	}
 	if err := cmd.Wait(); err != nil {
-		if !isExitStatus(err) && !isWaitError(err) {
+		if !canIgnore(err) {
 			return err
 		}
 	}
@@ -37,8 +37,24 @@ func (c *Cmd) Wait() error {
 	return c.cmd().Wait()
 }
 
+// Errors we can safely ignore when closing the process
+func canIgnore(err error) bool {
+	return isExitStatus(err) ||
+		isInterrupt(err) ||
+		isKilled(err) ||
+		isWaitError(err)
+}
+
 func isExitStatus(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "exit status ")
+}
+
+func isInterrupt(err error) bool {
+	return err != nil && err.Error() == `signal: interrupt`
+}
+
+func isKilled(err error) bool {
+	return err != nil && err.Error() == `signal: killed`
 }
 
 func isWaitError(err error) bool {


### PR DESCRIPTION
When closing a process, interrupt, then kill signals are sent to the process to shut it down.

We weren't handling a class of errors that can pop up. By not handling these errors, we were breaking out of the watch loop and losing live reload.

See this comment for more details: https://github.com/livebud/bud/issues/7#issuecomment-1126956511