### PR TITLE
specify 127.0.0.1 for hotServer

### DIFF
--- a/runtime/command/run/run.go
+++ b/runtime/command/run/run.go
@@ -115,5 +115,6 @@ func (c *Command) startApp(ctx context.Context, hotServer *hot.Server) error {
 }
 
 func (c *Command) startHot(ctx context.Context, hotServer *hot.Server) error {
-	return hotServer.ListenAndServe(ctx, ":35729")
+	// TODO: host should be dynamic
+	return hotServer.ListenAndServe(ctx, "127.0.0.1:35729")
 }


### PR DESCRIPTION
Specifying `127.0.0.1` with the port for the hotServer fixes an issue where a Windows browser was unable to connect to the hotServer running on WSL.

![image](https://user-images.githubusercontent.com/4244606/168481899-28b6a596-2936-45f5-a0a9-953a263e5f92.png)
_Full URL `http://127.0.0.1:35729/?page=%2Fbud%2Fview%2Findex.svelte`_
