### PR TITLE
Move build cache and fallback to copying

### DIFF
--- a/example/basic/view/index.svelte
+++ b/example/basic/view/index.svelte
@@ -6,7 +6,8 @@
 
 <style>
   h1 {
-    background: red;
+    background: blue;
+    padding: 20px;
     color: white;
   }
 </style>

--- a/internal/bud/bud.go
+++ b/internal/bud/bud.go
@@ -51,7 +51,7 @@ func Load(module *gomod.Module) (*Compiler, error) {
 	}
 	return &Compiler{
 		module: module,
-		bcache: buildcache.Default(),
+		bcache: buildcache.Default(module),
 		Env:    env,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,

--- a/internal/buildcache/buildcache.go
+++ b/internal/buildcache/buildcache.go
@@ -14,11 +14,9 @@ import (
 	"github.com/livebud/bud/package/gomod"
 )
 
-func Default() *Cache {
+func Default(module *gomod.Module) *Cache {
 	return &Cache{
-		// TODO: make this configurable
-		// TODO: use the user cache, once we have a way to clean up
-		Dir: filepath.Join(os.TempDir(), "bud", "cache"),
+		Dir: filepath.Join(module.Directory(), "bud", "cache"),
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -30,21 +30,21 @@ func Parse(args []string) int {
 
 func parse(args []string) error {
 	// $ bud
-	bud := new(command.Bud)
+	bud := command.New()
 	cli := commander.New("bud")
 	cli.Flag("chdir", "Change the working directory").Short('C').String(&bud.Dir).Default(".")
 	cli.Args("args").Strings(&bud.Args)
 	cli.Run(bud.Run)
 
 	{ // $ bud create <app>
-		cmd := &create.Command{Bud: bud}
+		cmd := create.New(bud)
 		cli := cli.Command("create", "create a new project")
 		cli.Arg("dir").String(&cmd.Dir)
 		cli.Run(cmd.Run)
 	}
 
 	{ // $ bud run
-		cmd := &run.Command{Bud: bud}
+		cmd := run.New(bud)
 		cli := cli.Command("run", "run the development server")
 		cli.Flag("embed", "embed the assets").Bool(&bud.Flag.Embed).Default(false)
 		cli.Flag("hot", "hot reload the frontend").Bool(&bud.Flag.Hot).Default(true)
@@ -54,7 +54,7 @@ func parse(args []string) error {
 	}
 
 	{ // $ bud build
-		cmd := &build.Command{Bud: bud}
+		cmd := build.New(bud)
 		cli := cli.Command("build", "build the production server")
 		cli.Flag("embed", "embed the assets").Bool(&bud.Flag.Embed).Default(true)
 		cli.Flag("hot", "hot reload the frontend").Bool(&bud.Flag.Hot).Default(false)
@@ -66,7 +66,7 @@ func parse(args []string) error {
 		cli := cli.Command("tool", "extra tools")
 
 		{ // $ bud tool di
-			cmd := &di.Command{Bud: bud}
+			cmd := di.New(bud)
 			cli := cli.Command("di", "dependency injection generator")
 			cli.Flag("dependency", "generate dependency provider").Short('d').Strings(&cmd.Dependencies)
 			cli.Flag("external", "mark dependency as external").Short('e').Strings(&cmd.Externals).Optional()
@@ -78,19 +78,19 @@ func parse(args []string) error {
 		}
 
 		{ // $ bud tool v8
-			cmd := &v8.Command{Bud: bud}
+			cmd := v8.New()
 			cli := cli.Command("v8", "Execute Javascript with V8 from stdin")
 			cli.Run(cmd.Run)
 
 			{ // $ bud tool v8 client
-				cmd := &v8client.Command{Bud: bud}
+				cmd := v8client.New()
 				cli := cli.Command("client", "V8 client used during development")
 				cli.Run(cmd.Run)
 			}
 		}
 
 		{ // $ bud tool cache
-			cmd := &cache.Command{}
+			cmd := cache.New(bud)
 			cli := cli.Command("cache", "Manage the build cache")
 
 			{ // $ bud tool cache clean
@@ -101,7 +101,7 @@ func parse(args []string) error {
 	}
 
 	{ // $ bud version
-		cmd := &version.Command{}
+		cmd := version.New()
 		cli := cli.Command("version", "Show package versions")
 		cli.Arg("key").String(&cmd.Key).Default("")
 		cli.Run(cmd.Run)

--- a/internal/command/build/build.go
+++ b/internal/command/build/build.go
@@ -7,18 +7,22 @@ import (
 	"github.com/livebud/bud/internal/command"
 )
 
+func New(bud *command.Bud) *Command {
+	return &Command{bud}
+}
+
 type Command struct {
-	Bud *command.Bud
+	bud *command.Bud
 }
 
 func (c *Command) Run(ctx context.Context) error {
 	// Load the compiler
-	compiler, err := bud.Find(c.Bud.Dir)
+	compiler, err := bud.Find(c.bud.Dir)
 	if err != nil {
 		return err
 	}
 	// Compile the project CLI
-	project, err := compiler.Compile(ctx, &c.Bud.Flag)
+	project, err := compiler.Compile(ctx, &c.bud.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -8,6 +8,10 @@ import (
 	runtime_bud "github.com/livebud/bud/runtime/bud"
 )
 
+func New() *Bud {
+	return &Bud{}
+}
+
 // Bud command
 type Bud struct {
 	Flag runtime_bud.Flag

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 
@@ -151,10 +152,10 @@ func findBudModule() (*gomod.Module, error) {
 	return gomod.Find(dir)
 }
 
-// move first tries to rename `from` a directory from one location `to` another
-// directory. If `from` is on a different partition than `to`, the underlying
-// os.Rename can fail with an "invalid cross-device link" error. If this occurs
-// we'll fallback to copying all the files over recursively.
+// Move first tries to rename a directory `from` one location `to` another.
+// If `from` is on a different partition than `to`, the underlying os.Rename can
+// fail with an "invalid cross-device link" error. If this occurs we'll fallback
+// to copying the files over recursively.
 func move(from, to string) error {
 	if err := os.Rename(from, to); err != nil {
 		// If it's not an invalid cross-device link error, return the error
@@ -168,5 +169,5 @@ func move(from, to string) error {
 }
 
 func isInvalidCrossLink(err error) bool {
-	return err.Error() == "invalid cross-device link"
+	return strings.Contains(err.Error(), "invalid cross-device link")
 }

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -19,13 +19,17 @@ import (
 	"github.com/livebud/bud/package/gomod"
 )
 
+func New(bud *command.Bud) *Command {
+	return &Command{bud: bud}
+}
+
 type Command struct {
-	Bud *command.Bud
+	bud *command.Bud
 	Dir string
 }
 
 func (c *Command) Run(ctx context.Context) error {
-	dir := filepath.Join(c.Bud.Dir, c.Dir)
+	dir := filepath.Join(c.bud.Dir, c.Dir)
 	// Check if we can write into the directory
 	if err := checkDir(dir); err != nil {
 		return err

--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -10,8 +10,12 @@ import (
 	"github.com/livebud/bud/package/socket"
 )
 
+func New(bud *command.Bud) *Command {
+	return &Command{bud: bud}
+}
+
 type Command struct {
-	Bud  *command.Bud
+	bud  *command.Bud
 	Port string
 }
 
@@ -32,12 +36,12 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 	console.Info("Listening on http://" + host + ":" + port)
 	// Load the compiler
-	compiler, err := bud.Find(c.Bud.Dir)
+	compiler, err := bud.Find(c.bud.Dir)
 	if err != nil {
 		return err
 	}
 	// Compiler the project CLI
-	project, err := compiler.Compile(ctx, &c.Bud.Flag)
+	project, err := compiler.Compile(ctx, &c.bud.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/command/tool/cache/cache.go
+++ b/internal/command/tool/cache/cache.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+
+	"github.com/livebud/bud/internal/command"
+	"github.com/livebud/bud/package/gomod"
 )
 
+func New(bud *command.Bud) *Command {
+	return &Command{bud}
+}
+
 type Command struct {
+	bud *command.Bud
 }
 
 func (c *Command) Clean(ctx context.Context) error {
-	cacheDir := filepath.Join(os.TempDir(), "bud-compiler")
+	module, err := gomod.Find(c.bud.Dir)
+	if err != nil {
+		return err
+	}
+	cacheDir := filepath.Join(module.Directory(), "bud", "cache")
 	return os.RemoveAll(cacheDir)
 }

--- a/internal/command/tool/di/di.go
+++ b/internal/command/tool/di/di.go
@@ -14,8 +14,12 @@ import (
 	"github.com/livebud/bud/package/parser"
 )
 
+func New(bud *command.Bud) *Command {
+	return &Command{bud: bud}
+}
+
 type Command struct {
-	Bud          *command.Bud
+	bud          *command.Bud
 	Target       string
 	Map          map[string]string
 	Dependencies []string
@@ -25,7 +29,7 @@ type Command struct {
 }
 
 func (c *Command) Run(ctx context.Context) error {
-	module, err := gomod.Find(c.Bud.Dir)
+	module, err := gomod.Find(c.bud.Dir)
 	if err != nil {
 		return err
 	}

--- a/internal/command/tool/v8/client/client.go
+++ b/internal/command/tool/v8/client/client.go
@@ -3,12 +3,14 @@ package client
 import (
 	"context"
 
-	"github.com/livebud/bud/internal/command"
 	"github.com/livebud/bud/package/js/v8server"
 )
 
+func New() *Command {
+	return &Command{}
+}
+
 type Command struct {
-	Bud *command.Bud
 }
 
 func (c *Command) Run(ctx context.Context) error {

--- a/internal/command/tool/v8/v8.go
+++ b/internal/command/tool/v8/v8.go
@@ -9,13 +9,15 @@ import (
 	"os"
 	"strings"
 
-	"github.com/livebud/bud/internal/command"
 	v8 "github.com/livebud/bud/package/js/v8"
 	"github.com/mattn/go-isatty"
 )
 
+func New() *Command {
+	return &Command{}
+}
+
 type Command struct {
-	Bud *command.Bud
 }
 
 func (c *Command) Run(ctx context.Context) error {

--- a/internal/command/version/version.go
+++ b/internal/command/version/version.go
@@ -9,6 +9,10 @@ import (
 	"github.com/livebud/bud/internal/version"
 )
 
+func New() *Command {
+	return &Command{}
+}
+
 type Command struct {
 	Key string
 }

--- a/runtime/bud/project.go
+++ b/runtime/bud/project.go
@@ -16,7 +16,7 @@ func New(fsys *overlay.FileSystem, module *gomod.Module) *Project {
 	return &Project{
 		fsys:   fsys,
 		module: module,
-		bcache: buildcache.Default(),
+		bcache: buildcache.Default(module),
 		Env:    os.Environ(),
 		Stderr: os.Stderr,
 		Stdout: os.Stdout,


### PR DESCRIPTION
This PR changes where cached builds are placed:

- From: `$TMPDIR/bud/cache`
- To: `$YOUR_APP/bud/cache`

to fix #27. 

The `./bud/` directory should generally be ignored by source control anyways. If you do choose to vendor the `./bud/` directory, you can always git ignore `./bud/cache/`. You could also run `bud tool cache clean` to remove the `bud/cache` directory.

We may find that this clutters up the project's `bud/` directory too much, but it's better to try and unblock people, then figure out the ideal solution later.

I also hopefully fixed #30 and #46 with https://github.com/livebud/bud/pull/50/commits/b90663032b6f53f140ccaa9242550d9d29cf984e.

This PR is a bit messier than I would have liked, but I took the opportunity to do some additional testing and cleanup. The main changes are in: 
- https://github.com/livebud/bud/pull/50/commits/f88458eb2146c2effcb69d862cf03922f554c0b3
- https://github.com/livebud/bud/pull/50/commits/b90663032b6f53f140ccaa9242550d9d29cf984e

So overall, I'm hoping this PR resolves #27, #30 and #46 🤞 
