### PR TITLE
Add comment in README.md about go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ Commands:
 
 The following software is required to use Bud.
 
-- Node v14+ 
+- Node v14+
+   
    This is a temporary requirement that we plan to remove in [v0.3](https://github.com/livebud/bud/discussions/21)   
+   
 - Go v1.16+
-   Bud relies heavily on `io/fs` and will take advantage of generics in the future, so while v1.16 will work, we suggest running Go v1.18+ if you can.
+   
+   Bud relies heavily on `io/fs` and will take advantage of generics in the future, so while Go v1.16 will work, we suggest running Go v1.18+ if you can.
 
 # Your First Project
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Commands:
   version  Show package versions
 ```
 
+### `go` version
+
+Bud relies heavily on `io/fs` and will take advantage of generics in the future, so we suggest running Go 1.18+.
+
 # Your First Project
 
 With bud installed, you can now scaffold a new project:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ Commands:
   version  Show package versions
 ```
 
-### `go` version
+# Requirements
 
-Bud relies heavily on `io/fs` and will take advantage of generics in the future, so we suggest running Go 1.18+.
+The following software is required to use Bud.
+
+- Node v14+ 
+   This is a temporary requirement that we plan to remove in [v0.3](https://github.com/livebud/bud/discussions/21)   
+- Go v1.16+
+   Bud relies heavily on `io/fs` and will take advantage of generics in the future, so while v1.16 will work, we suggest running Go v1.18+ if you can.
 
 # Your First Project
 


### PR DESCRIPTION
This adds a short line to the `README.md` which highlights the recommended `go` version that should be used to run Bud.

I was caught out by #45 too. Please let me know if you have any questions and great job on Bud so far - I've been searching for something like this for a while.