### PR TITLE
readme: add background/philosophy section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,31 @@ Congrats! You're running your first web server with Bud. The welcome server is y
 
 ![CleanShot 2022-05-12 at 22.00.19@2x.png](https://denim-cub-301.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2Fdb7f750b-a699-4117-ac07-303124e5d2f4%2FCleanShot_2022-05-12_at_22.00.192x.png?table=block&id=9488d91f-b72d-4c6d-9ce0-358c31f7f964&spaceId=faf0f409-6e25-40a4-871e-3b311037350f&width=2000&userId=&cache=v2)
 
-Check out the [Hacker News demo](https://www.youtube.com/watch?v=LoypcRqn-xA), [read the documentation](https://denim-cub-301.notion.site/Hey-Bud-4d81622cc49942f9917c5033e5205c69#156ea69b8d044bacb65fc2897f3e52b8), [schedule a quick call](https://cal.com/d/5iDN6qWZCLGMipwhFqhY3i/30min) or go on your own adventure. The only limit is your imagination.
+## How did Bud come into existence?
+
+I started working on Bud two years ago after seeing how productive people could be in [Laravel](https://laravel.com/), and I wanted the same for Go, so I decided to try creating Laravel for the Go ecosystem. However, my first version after 6 months needed to scaffold many files just to get started. If you are coming from [Rails](https://github.com/rails/rails) or Laravel you may shrug and consider this as pretty normal. 
+
+Unfortunately, I have also been spoiled by the renaissance in frontend frameworks like [Next.js](https://nextjs.org/) that start barebones and then every file you add incrementally enhances your web application. This keeps the initial complexity under control.
+
+With this additional inspiration, I worked on the next iteration for the ensuing 18 months. 
+
+The goals are now:
+
+* Generate files only as you need them. Keep these generated files away from your application code and give developers the choice to keep them out of source control.
+
+* Feel like using a modern JS framework. This means it should work with [multiple](https://github.com/livebud/bud/discussions/8) modern frontend frameworks like [Svelte](https://svelte.dev/) and [React](https://reactjs.org/), support [live reload](https://denim-cub-301.notion.site/Hey-Bud-4d81622cc49942f9917c5033e5205c69#4c7dff15ef3e458587b81fb9b1819afb), and have [server-side rendering](https://www.reddit.com/r/golang/comments/uoxocj/bud_the_fullstack_web_framework_for_go_developers/i8ke92h/?utm_source=reddit&utm_medium=web2x&context=3) for better performance and SEO.
+
+* The framework should be extensible from Day 1. Bud is too ambitious for one person. We're going to need an ambitious community behind this framework.
+
+* Bud should provide high-level APIs for developers while using performant low-level Go code under the covers.
+
+* Bud should compile to a single binary that contains the entire web app and can be copied to a server that doesn't even have Go installed.
+
+## Next Steps
+
+Check out the Hacker News [demo](https://www.youtube.com/watch?v=LoypcRqn-xA), read the [documentation](https://denim-cub-301.notion.site/Hey-Bud-4d81622cc49942f9917c5033e5205c69#156ea69b8d044bacb65fc2897f3e52b8), [schedule a quick call](https://cal.com/d/5iDN6qWZCLGMipwhFqhY3i/30min) or go on your own adventure. The only limit is your imagination.
+
+Recent discussions: [Reddit](https://www.reddit.com/r/golang/comments/uoxocj/bud_the_fullstack_web_framework_for_go_developers/), [Hacker News](https://news.ycombinator.com/item?id=31371340), [Twitter](https://twitter.com/golivebud)
 
 ## Contributing
 


### PR DESCRIPTION
Hi @matthewmueller, random gopher here. This project certainly seems to have a bunch of promise!

This PR attempts to capture some of the philosophy of the project that you described elsewhere, but is not currently in the README. 

The text is a slightly cut down version of what you posted to Reddit and Hacker News. (Empirically, that text seems to have been effective 😅 ).

My guess is that with more time, you would probably not use this text exactly (e.g., maybe your style is to not use the first person in a README), but I think having something like this sooner rather than later would be helpful for the project, and then it could be improved later. (And selfishly, I'd like to point some people to this repo, and it would be nice to have more context here).

I also included some pointers to other discussions at the bottom.

Happy for any feedback, or feel free to reject or tweak any or all of this!

Finally, I used the phrase "How did Bud come into existence?" for the new section header, but alternatives could be "Philosophy", "Background", "Why does this exist?", "Where did this come from?", or something else.