### PR TITLE
Support other Actions

### DIFF
--- a/package/router/radix/tree.go
+++ b/package/router/radix/tree.go
@@ -75,7 +75,7 @@ type tree struct {
 }
 
 func (t *tree) Insert(route string, handler http.Handler) error {
-	lexer := lex.New(route)
+	lexer := lex.New(strings.ToLower(route))
 	var tokens lex.Tokens
 	for {
 		token := lexer.Next()

--- a/package/router/router_test.go
+++ b/package/router/router_test.go
@@ -184,8 +184,8 @@ func TestTrailingSlash(t *testing.T) {
 func TestInsensitive(t *testing.T) {
 	ok(t, &test{
 		routes: []*route{
-			{method: "GET", route: "/HI", err: `route "/HI": uppercase letters are not allowed "H"`},
-			{method: "GET", route: "/hi"},
+			{method: "GET", route: "/HI"},
+			{method: "GET", route: "/hi", err: `radix: "/hi" is already in the tree`},
 		},
 		requests: []*request{
 			{method: "GET", path: "/HI", status: 308, location: "/hi", body: "<a href=\"/hi\">Permanent Redirect</a>.\n\n"},


### PR DESCRIPTION
Fixes #54

Routes were already attempting be to registered but failing due to using the require initial uppercase letter of the func name. This change simply lowercases the route when registering.