### PR TITLE
Add support for custom controller actions

### DIFF
--- a/package/router/radix/tree.go
+++ b/package/router/radix/tree.go
@@ -267,6 +267,10 @@ func insertWild(parent *node, child *node) error {
 
 // Match the path to a route in the tree
 func (t *tree) Match(path string) (*Match, bool) {
+	// A tree without any routes shouldn't panic
+	if t.root == nil {
+		return nil, false
+	}
 	match := t.match(t.root, path, Slots{})
 	if match == nil {
 		return nil, false

--- a/package/router/radix/tree_test.go
+++ b/package/router/radix/tree_test.go
@@ -337,3 +337,12 @@ func TestWildcard(t *testing.T) {
 		},
 	})
 }
+
+func TestNoRoutes(t *testing.T) {
+	ok(t, &test{
+		requests: []*request{
+			{path: "/", nomatch: true},
+			{path: "/a", nomatch: true},
+		},
+	})
+}

--- a/runtime/generator/controller/loader.go
+++ b/runtime/generator/controller/loader.go
@@ -186,7 +186,7 @@ func (l *loader) loadActionRoute(controllerRoute, actionName string) string {
 	case "Index", "Create":
 		return controllerRoute
 	default:
-		return path.Join(controllerRoute, text.Path(actionName))
+		return path.Join(controllerRoute, text.Path(text.Lower(actionName)))
 	}
 }
 

--- a/runtime/generator/web/loader.go
+++ b/runtime/generator/web/loader.go
@@ -161,7 +161,7 @@ func (l *loader) loadActionRoute(basePath, actionName string) string {
 	case "Index", "Create":
 		return basePath
 	default:
-		return path.Join(basePath, text.Path(actionName))
+		return path.Join(basePath, text.Lower(text.Path(actionName)))
 	}
 }
 


### PR DESCRIPTION
This PR adds support for custom controller actions like `func (c *Controller) About() { ... }` mapping to `GET /about`. It also fixes a panic when trying to match when there are no routes.

Thanks to @theEyeD's investigation in #67, I was able to add this in a few minutes.

Fixes #54
Closes #67
