### PR TITLE
Improve hot reload

### DIFF
--- a/package/watcher/watcher.go
+++ b/package/watcher/watcher.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -133,6 +134,8 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 	// Note: The FAQ currently says it needs to be in a separate Go routine
 	// https://github.com/fsnotify/fsnotify#faq, so we'll do that.
 	eg, ctx := errgroup.WithContext(ctx)
+	// Start timer
+	startTime := time.Now()
 	eg.Go(func() error {
 		for {
 			select {
@@ -162,11 +165,17 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 					}
 
 				// Handle write events
-				case op&fsnotify.Write != 0:
+				// Currently, there is an issue with fsnotify which may register multiple events
+				// in a single change, so we have to ignore events that is triggered too
+				// closely together (details in #70)
+				// If there are multiple events in one file change, this only accept the first one.
+				case op&fsnotify.Write != 0 && time.Since(startTime).Milliseconds() > 10:
 					if err := write(evt.Name); err != nil {
 						return err
 					}
 				}
+
+				startTime = time.Now()
 			}
 		}
 	})

--- a/runtime/command/run/run.go
+++ b/runtime/command/run/run.go
@@ -2,8 +2,11 @@ package run
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
+	"time"
 
 	"github.com/livebud/bud/package/exe"
 	"github.com/livebud/bud/package/log/console"
@@ -49,35 +52,66 @@ func (c *Command) compileAndStart(ctx context.Context, ln net.Listener) (*exe.Cm
 	return process, nil
 }
 
+func replacePreviousLine(msg string) {
+	// Move cursor up and delete line based on ANSI Escape Sequences: https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
+	switch runtime.GOOS {
+	case "windows":
+		// TODO: Test this on Windows, don't know will it work or not
+		fmt.Print("\033[1A\033[0K")
+	case "linux":
+		fmt.Print("\033[1A\033[0K")
+	default:
+		console.Error("Can't detect your operating system")
+	}
+	console.Info(msg)
+}
+
 func (c *Command) startApp(ctx context.Context, hotServer *hot.Server) error {
 	listener, err := socket.Load(c.Port)
 	if err != nil {
 		return err
 	}
+
+	// Init reload counter variable
+	totalReload := 0
+
 	// Compile and start the project
 	process, err := c.compileAndStart(ctx, listener)
 	if err != nil {
 		// TODO: de-duplicate with the watcher above
 		console.Error(err.Error())
 		if err := watcher.Watch(ctx, ".", func(path string) error {
+			totalReload++                       // Increase reload count
+			startTime := time.Now()             // Start timer
+			replacePreviousLine("Reloading...") // Handle reloading message
+
 			process, err = c.compileAndStart(ctx, listener)
 			if err != nil {
 				console.Error(err.Error())
+				console.Error("") // Avoid error messages getting overridden
+				totalReload = 0   // Reset reload counter
 				return nil
 			}
-			// TODO: host should be dynamic
-			console.Info("Ready on http://127.0.0.1" + c.Port)
+
+			// Time elapsed response
+			timeElapsed := time.Since(startTime).Milliseconds()
+			replacePreviousLine(fmt.Sprintf("Ready in %dms (x%d)", timeElapsed, totalReload))
 			return watcher.Stop
 		}); err != nil {
 			return err
 		}
 	}
 	defer process.Close()
+
 	// Start watching
 	if err := watcher.Watch(ctx, ".", func(path string) error {
 		switch filepath.Ext(path) {
 		// Re-compile the app and restart the Go server
 		case ".go":
+			totalReload++                       // Increase reload count
+			startTime := time.Now()             // Start timer
+			replacePreviousLine("Reloading...") // Handle reloading message
+
 			// Trigger a reload if there's a hot reload server configured
 			if hotServer != nil {
 				// Exclamation point just means full page reload
@@ -85,20 +119,28 @@ func (c *Command) startApp(ctx context.Context, hotServer *hot.Server) error {
 			}
 			if err := process.Close(); err != nil {
 				console.Error(err.Error())
+				console.Error("") // Avoid error messages getting overridden
+				totalReload = 0   // Reset reload counter
 				return nil
 			}
 			app, err := c.Project.Compile(ctx, c.Flag)
 			if err != nil {
 				console.Error(err.Error())
+				console.Error("") // Avoid error messages getting overridden
+				totalReload = 0   // Reset reload counter
 				return nil
 			}
 			process, err = app.Start(ctx, listener)
 			if err != nil {
 				console.Error(err.Error())
+				console.Error("") // Avoid error messages getting overridden
+				totalReload = 0   // Reset reload counter
 				return nil
 			}
-			// TODO: host should be dynamic
-			console.Info("Ready on http://127.0.0.1" + c.Port)
+
+			// Time elapsed response
+			timeElapsed := time.Since(startTime).Milliseconds()
+			replacePreviousLine(fmt.Sprintf("Ready in %dms (x%d)", timeElapsed, totalReload))
 			return nil
 		// Hot reload the page
 		default:


### PR DESCRIPTION
### New front end

- Welcome dashboard:

```
Listening on http://127.0.0.1:3000
Ready in 300ms
```

- Better way of prompting successful reloads:

```
Ready in 144ms (x11)
```
### Fix [multiple reload messages](https://github.com/livebud/bud/pull/70#issuecomment-1132497113)