### PR TITLE
internal/testdir: attempt to reproduce occassional EOF error in CI

### DIFF
--- a/internal/testdir/testdir.go
+++ b/internal/testdir/testdir.go
@@ -185,8 +185,8 @@ func (d *Dir) mapfs() (fstest.MapFS, error) {
 }
 
 // Dir returns the directory
-func (d *Dir) Dir() string {
-	return d.dir
+func (d *Dir) Path(subpaths ...string) string {
+	return filepath.Join(append([]string{d.dir}, subpaths...)...)
 }
 
 // Hash returns a file hash of our mapped file system

--- a/runtime/generator/program/program.go
+++ b/runtime/generator/program/program.go
@@ -64,7 +64,7 @@ func (p *Program) GenerateFile(ctx context.Context, fsys overlay.F, file *overla
 	provider, err := p.Injector.Wire(loadApp)
 	if err != nil {
 		// Don't wrap on purpose, this error gets swallowed up easily
-		return fmt.Errorf("program: unable to wire > %s", err)
+		return fmt.Errorf("program: unable to wire. %s", err)
 	}
 	for _, im := range provider.Imports {
 		imports.AddNamed(im.Name, im.Path)


### PR DESCRIPTION
Occassionally seeing:

```
Error: error: conjure: generate "bud/.app/program/program.go". program: unable to wire > di: unable to wire "app.com/bud/program".loadApp function. di: unable to find definition for param "app.com/bud/.app/web".*Server in "app.com/bud/.app/command".*Command . parser: unable to find declaration for "app.com/bud/.app/web".Server in "bud/.app/command/command.go". parser: unable to import package "bud/.app/web". conjure: generate "bud/.app/web/web.go". conjure: generate "bud/.app/controller/controller.go". 
parser: unable to import package "controller". controller/controller.go:1:1: expected 'package', found 'EOF'
```

This can happen when you have an empty `controller/controller.go` file. I haven't figured out yet why this occasionally happens.

This test didn't resolve it, but added a test just in case. Also made the error message that shows up more consistent.