### PR TITLE
WIP: V8Pipe support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       # Temporary fix to get the tests working until we pass the V8 client as a
       # os.Pipe
       - name: Install bud binary into $PATH
-        run: go install github.com/livebud/bud@latest
+        run: go install github.com/livebud/bud@v8pipe2
 
       - name: Install bud node_modules
         run: npm ci

--- a/internal/cli/testcli/testcli.go
+++ b/internal/cli/testcli/testcli.go
@@ -108,7 +108,12 @@ func (c *TestCLI) Start(ctx context.Context, args ...string) (app *App, stdout *
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to listen on socket path %q: %s", appSocketPath, err)
 	}
-	if err := c.cli.Inject("APP", appListener); err != nil {
+	appFile, err := appListener.File()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to get the app file listener %q: %s", appSocketPath, err)
+	}
+	// extrafile.Inject()
+	if err := c.cli.Inject("APP", appFile); err != nil {
 		return nil, nil, nil, err
 	}
 	// Start listening on a unix domain socket for the hot
@@ -117,7 +122,11 @@ func (c *TestCLI) Start(ctx context.Context, args ...string) (app *App, stdout *
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to listen on socket path %q: %s", hotSocketPath, err)
 	}
-	if err := c.cli.Inject("HOT", hotListener); err != nil {
+	hotFile, err := hotListener.File()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to get the hot file listener %q: %s", hotSocketPath, err)
+	}
+	if err := c.cli.Inject("HOT", hotFile); err != nil {
 		return nil, nil, nil, err
 	}
 	// Attach to stdout and stderr

--- a/internal/cli/testcli/testcli.go
+++ b/internal/cli/testcli/testcli.go
@@ -87,7 +87,7 @@ func listen(path string) (socket.Listener, *http.Client, error) {
 		return nil, nil, err
 	}
 	client := &http.Client{
-		Timeout:   30 * time.Second,
+		Timeout:   5 * time.Second,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/cli/testcli/testcli.go
+++ b/internal/cli/testcli/testcli.go
@@ -87,7 +87,14 @@ func listen(path string) (socket.Listener, *http.Client, error) {
 		return nil, nil, err
 	}
 	client := &http.Client{
-		Timeout:   10 * time.Second,
+		// This is extra high right now because we don't currently have any signal
+		// that we've built the app and `bud run --embed` can take a long time. This
+		// is going to slow down legitimately failing requests, so it's a very
+		// temporary solution.
+		//
+		// TODO: support getting a signal that we've built the app, then lower this
+		// deadline.
+		Timeout:   60 * time.Second,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/cli/testcli/testcli.go
+++ b/internal/cli/testcli/testcli.go
@@ -87,7 +87,7 @@ func listen(path string) (socket.Listener, *http.Client, error) {
 		return nil, nil, err
 	}
 	client := &http.Client{
-		Timeout:   5 * time.Second,
+		Timeout:   10 * time.Second,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/cli/tool/v8/serve/serve.go
+++ b/internal/cli/tool/v8/serve/serve.go
@@ -1,7 +1,8 @@
-package client
+package serve
 
 import (
 	"context"
+	"os"
 
 	"github.com/livebud/bud/package/js/v8server"
 )
@@ -10,5 +11,5 @@ type Command struct {
 }
 
 func (c *Command) Run(ctx context.Context) error {
-	return v8server.Serve()
+	return v8server.New(os.Stdin, os.Stdout).Serve()
 }

--- a/internal/extrafile/extrafile.go
+++ b/internal/extrafile/extrafile.go
@@ -6,35 +6,13 @@ import (
 	"syscall"
 )
 
-type File interface {
-	File() (*os.File, error)
-}
-
-// Prepare is a low-level function for preparing files to be passed through a
-// subprocess via "os/exec".*Cmd.ExtraFiles. The prefix must be the same on both
-// sides. Use the offset to prepare multiple extra files to be passed through.
-// The offset should start at 0.
-func Prepare(prefix string, offset int, files ...File) ([]*os.File, []string, error) {
-	lenFiles := len(files)
-	osFiles := make([]*os.File, lenFiles)
-	for i, file := range files {
-		osFile, err := file.File()
-		if err != nil {
-			return nil, nil, err
-		}
-		osFiles[i] = osFile
-	}
-	env := PrepareEnv(prefix, offset, osFiles...)
-	return osFiles, env, nil
-}
-
-// PrepareEnv prepares the environment variables so the file descriptors can be
+// prepareEnv prepares the environment variables so the file descriptors can be
 // recovered in the subprocess.
 //
 // This is also a half-hearted attempt to support systemd out of the box.
 // https://github.com/coreos/go-systemd/blob/main/activation/files_unix.go
 // TODO: test systemd support
-func PrepareEnv(prefix string, offset int, files ...*os.File) []string {
+func prepareEnv(prefix string, offset int, files ...*os.File) []string {
 	if len(files) == 0 {
 		return nil
 	}
@@ -42,6 +20,27 @@ func PrepareEnv(prefix string, offset int, files ...*os.File) []string {
 		prefix + "_FDS_START=" + strconv.Itoa(offset),
 		prefix + "_FDS=" + strconv.Itoa(len(files)),
 	}
+}
+
+// Inject files and environment for a subprocess
+func Inject(extras *[]*os.File, env *[]string, prefix string, files ...*os.File) {
+	if len(files) == 0 {
+		return
+	}
+	offset := len(*extras)
+	environ := prepareEnv(prefix, offset, files...)
+	*extras = append(*extras, files...)
+	*env = append(*env, environ...)
+}
+
+// Forward an existing prefix into a subprocesses ExtraFiles and Env
+// parameters.
+func Forward(extras *[]*os.File, env *[]string, prefix string) {
+	files := Load(prefix)
+	if len(files) == 0 {
+		return
+	}
+	Inject(extras, env, prefix, files...)
 }
 
 // Loading extra file descriptors should start at 3 because the first 3 are:
@@ -68,17 +67,8 @@ func Load(prefix string) []*os.File {
 	var files []*os.File
 	for fd := startAt + offset; fd < startAt+offset+len; fd++ {
 		syscall.CloseOnExec(fd)
-		name := prefix + "_FD_" + strconv.Itoa(fd)
+		name := prefix + "_FD_" + strconv.Itoa(fd-startAt)
 		files = append(files, os.NewFile(uintptr(fd), name))
 	}
 	return files
-}
-
-// Forward existing file descriptors to a subprocess
-func Forward(prefix string, offset int) (files []*os.File, env []string) {
-	files = Load(prefix)
-	if len(files) == 0 {
-		return files, env
-	}
-	return files, PrepareEnv(prefix, offset, files...)
 }

--- a/internal/extrafile/extrafile_test.go
+++ b/internal/extrafile/extrafile_test.go
@@ -64,14 +64,6 @@ func TestUnixPassthrough(t *testing.T) {
 		hotSocket, hotClient, err := listen(filepath.Join(dir, "hot.sock"))
 		is.NoErr(err)
 		defer hotSocket.Close()
-		// appFiles, appEnv, err := extrafile.Prepare("APP", 0, appSocket)
-		// is.NoErr(err)
-		// is.Equal(len(appFiles), 1)
-		// is.Equal(len(appEnv), 2)
-		// hotFiles, hotEnv, err := extrafile.Prepare("HOT", 1, hotSocket)
-		// is.NoErr(err)
-		// is.Equal(len(hotFiles), 1)
-		// is.Equal(len(hotEnv), 2)
 		// Ignore -test.count otherwise this will continue recursively
 		var args []string
 		for _, arg := range os.Args[1:] {
@@ -208,14 +200,6 @@ func TestTCPPassthrough(t *testing.T) {
 		hotSocket, hotClient, err := listen(":0")
 		is.NoErr(err)
 		defer hotSocket.Close()
-		// appFiles, appEnv, err := extrafile.Prepare("APP", 0, appSocket)
-		// is.NoErr(err)
-		// is.Equal(len(appFiles), 1)
-		// is.Equal(len(appEnv), 2)
-		// hotFiles, hotEnv, err := extrafile.Prepare("HOT", 1, hotSocket)
-		// is.NoErr(err)
-		// is.Equal(len(hotFiles), 1)
-		// is.Equal(len(hotEnv), 2)
 		// Ignore -test.count otherwise this will continue recursively
 		var args []string
 		for _, arg := range os.Args[1:] {

--- a/package/js/v8server/server.go
+++ b/package/js/v8server/server.go
@@ -1,7 +1,7 @@
 package v8server
 
 import (
-	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,18 +12,49 @@ import (
 	"github.com/livebud/bud/package/js/v8client"
 )
 
-func Serve() error {
-	server := &Server{os.Stdin, os.Stdout}
-	return server.Serve()
+// empty
+var emptyCloser = func() error { return nil }
+
+// Pipe creates a V8 server from a file pipe
+func Pipe() (*Server, error) {
+	r1, w2, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	r2, w1, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	server := &Server{
+		reader: r1,
+		writer: w1,
+		files:  []*os.File{r2, w2},
+		closer: func() error {
+			if w1.Close(); err != nil {
+				return err
+			}
+			if w2.Close(); err != nil {
+				return err
+			}
+			return err
+		},
+	}
+	return server, nil
 }
 
 func New(reader io.ReadCloser, writer io.WriteCloser) *Server {
-	return &Server{reader, writer}
+	return &Server{
+		reader: reader,
+		writer: writer,
+		closer: emptyCloser,
+	}
 }
 
 type Server struct {
 	reader io.ReadCloser
 	writer io.WriteCloser
+	files  []*os.File
+	closer func() error
 }
 
 func (s *Server) Serve() error {
@@ -31,8 +62,8 @@ func (s *Server) Serve() error {
 	if err != nil {
 		return err
 	}
-	dec := gob.NewDecoder(s.reader)
-	enc := gob.NewEncoder(s.writer)
+	dec := json.NewDecoder(s.reader)
+	enc := json.NewEncoder(s.writer)
 	for {
 		// Decode messages into input
 		var in v8client.Input
@@ -61,7 +92,17 @@ func (s *Server) Serve() error {
 	}
 }
 
-func script(vm js.VM, enc *gob.Encoder, path, code string) error {
+// Files returns a list of files that can be used to connect to the server
+func (s *Server) Files() []*os.File {
+	return s.files
+}
+
+// Close the server
+func (s *Server) Close() error {
+	return s.closer()
+}
+
+func script(vm js.VM, enc *json.Encoder, path, code string) error {
 	var out v8client.Output
 	err := vm.Script(path, code)
 	if err != nil {
@@ -70,7 +111,7 @@ func script(vm js.VM, enc *gob.Encoder, path, code string) error {
 	return enc.Encode(out)
 }
 
-func eval(vm js.VM, enc *gob.Encoder, path, code string) error {
+func eval(vm js.VM, enc *json.Encoder, path, code string) error {
 	var out v8client.Output
 	result, err := vm.Eval(path, code)
 	if err != nil {

--- a/package/js/v8server/server_test.go
+++ b/package/js/v8server/server_test.go
@@ -30,7 +30,6 @@ func TestClient(t *testing.T) {
 
 func TestMultiClient(t *testing.T) {
 	is := is.New(t)
-
 	cmd := exec.Command("go", "run", "test-server.go")
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
@@ -40,9 +39,6 @@ func TestMultiClient(t *testing.T) {
 	is.NoErr(err)
 	is.NoErr(cmd.Start())
 	client := v8client.New(stdout, stdin)
-	// server := &v8server.Server{r2, w1}
-	// eg := new(errgroup.Group)
-	// eg.Go(func() error { return server.Serve() })
 	err = client.Script("fib.js", `
 		function fib(num) {
 			if (num <= 1) return 1;

--- a/package/js/v8server/test-server.go
+++ b/package/js/v8server/test-server.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	if err := v8server.Serve(); err != nil {
+	if err := v8server.New(os.Stdin, os.Stdout).Serve(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}

--- a/package/socket/child.go
+++ b/package/socket/child.go
@@ -14,5 +14,5 @@ func From(file *os.File) (Listener, error) {
 	if err := file.Close(); err != nil {
 		return nil, err
 	}
-	return listener{ln}, nil
+	return &listener{ln}, nil
 }

--- a/package/socket/parent.go
+++ b/package/socket/parent.go
@@ -24,12 +24,16 @@ type file interface {
 	File() (*os.File, error)
 }
 
-func (l listener) File() (*os.File, error) {
+func (l *listener) File() (*os.File, error) {
 	filer, ok := l.Listener.(file)
 	if !ok {
 		return nil, fmt.Errorf("socket: %s is not a file", l.Listener.Addr().String())
 	}
 	return filer.File()
+}
+
+func (l *listener) Close() error {
+	return l.Listener.Close()
 }
 
 // Listen on a path or port
@@ -52,7 +56,7 @@ func Listen(path string) (Listener, error) {
 		if err != nil {
 			return nil, err
 		}
-		return listener{unix}, nil
+		return &listener{unix}, nil
 	}
 	// Otherwise, we listen on a TCP port
 	addr, err := net.ResolveTCPAddr("tcp", url.Host)
@@ -63,7 +67,7 @@ func Listen(path string) (Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	return listener{tcp}, nil
+	return &listener{tcp}, nil
 }
 
 func Transport(path string) (http.RoundTripper, error) {

--- a/runtime/generator/view/view_test.go
+++ b/runtime/generator/view/view_test.go
@@ -54,6 +54,9 @@ func TestHello(t *testing.T) {
 	is.In(stderr.String(), "info: Ready on")
 }
 
+// Note: if this test is failing due to context deadline exceeding, you
+// probably just need update the timeout. Right now we don't have a signal
+// that Start() has built and started the app.
 func TestHelloEmbed(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()

--- a/runtime/generator/view/view_test.go
+++ b/runtime/generator/view/view_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestHello(t *testing.T) {
+	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -55,6 +56,7 @@ func TestHello(t *testing.T) {
 }
 
 func TestHelloEmbed(t *testing.T) {
+	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/runtime/generator/view/view_test.go
+++ b/runtime/generator/view/view_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestHello(t *testing.T) {
-	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -56,7 +55,6 @@ func TestHello(t *testing.T) {
 }
 
 func TestHelloEmbed(t *testing.T) {
-	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/scripts/test-slice-pointer/main.go
+++ b/scripts/test-slice-pointer/main.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func main() {
+	files := []*File{{"A"}, {"B"}}
+	add(&files, &File{"C"})
+	fmt.Println(files)
+}
+
+type File struct {
+	Name string
+}
+
+func add(list *[]*File, files ...*File) {
+	*list = append(*list, files...)
+}

--- a/scripts/test-socket-passthrough/child/main.go
+++ b/scripts/test-socket-passthrough/child/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/livebud/bud/internal/sig"
+
+	"github.com/livebud/bud/package/socket"
+
+	"github.com/livebud/bud/internal/extrafile"
+)
+
+func main() {
+	if err := run(sig.Trap(context.Background(), os.Interrupt)); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) error {
+	files := extrafile.Load("APP")
+	if len(files) == 0 {
+		return fmt.Errorf("no files passed through")
+	}
+	listener, err := socket.From(files[0])
+	if err != nil {
+		return err
+	}
+	server := &http.Server{
+		Addr: ":0",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("hello world"))
+		}),
+	}
+	eg := new(errgroup.Group)
+	eg.Go(func() error {
+		fmt.Println("listening on", listener.Addr())
+		return server.Serve(listener)
+	})
+	<-ctx.Done()
+	if err := server.Shutdown(context.Background()); err != nil {
+		return err
+	}
+	if err := eg.Wait(); err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/scripts/test-socket-passthrough/main.go
+++ b/scripts/test-socket-passthrough/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/livebud/bud/internal/extrafile"
+	"github.com/livebud/bud/package/exe"
+	"github.com/livebud/bud/package/socket"
+)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) error {
+	listener, err := socket.Listen(":0")
+	if err != nil {
+		return err
+	}
+	// run `go build`
+	childPath := filepath.Join(os.TempDir(), "test-socket-passthrough", "child")
+	cmd := exe.Command(ctx, "go", "build", "-o", childPath, "scripts/test-socket-passthrough/child/main.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	// Start the web server
+	cmd = exe.Command(ctx, childPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	appFile, err := listener.File()
+	if err != nil {
+		return err
+	}
+	extrafile.Inject(&cmd.ExtraFiles, &cmd.Env, "APP", appFile)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	res, err := http.DefaultClient.Get("http://" + listener.Addr().String())
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: " + res.Status)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Got body: " + string(body))
+	if err := cmd.Restart(context.Background()); err != nil {
+		return err
+	}
+	fmt.Println("restarted")
+	res, err = http.DefaultClient.Get("http://" + listener.Addr().String())
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: " + res.Status)
+	}
+	body, err = io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Got body: " + string(body))
+	if err := cmd.Close(); err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/scripts/test-v8-pipe/child/main.go
+++ b/scripts/test-v8-pipe/child/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/livebud/bud/internal/extrafile"
+	"github.com/livebud/bud/package/exe"
+	"github.com/livebud/bud/package/js/v8client"
+	"github.com/livebud/bud/package/socket"
+)
+
+func run(ctx context.Context) error {
+	listener, err := socket.Listen(":4444")
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+	fileListener, err := listener.File()
+	if err != nil {
+		return err
+	}
+	v8client, err := v8client.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if err := v8client.Script("script.js", "const __svelte__ = 3+3"); err != nil {
+		return err
+	}
+	fmt.Println("calling child")
+	cmd := exe.Command(ctx, "go", "run", "scripts/test-v8-pipe/grandchild/main.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	extrafile.Forward(&cmd.ExtraFiles, &cmd.Env, "V8")
+	extrafile.Inject(&cmd.ExtraFiles, &cmd.Env, "APP", fileListener)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/scripts/test-v8-pipe/grandchild/main.go
+++ b/scripts/test-v8-pipe/grandchild/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/livebud/bud/internal/extrafile"
+	"github.com/livebud/bud/package/js/v8client"
+	"github.com/livebud/bud/package/socket"
+)
+
+func run(ctx context.Context) error {
+	fmt.Println("calling grandchild")
+	// files := extrafile.Load("V8")
+	v8client, err := v8client.Load(ctx)
+	if err != nil {
+		return err
+	}
+	// v8client := v8client.New(files[0], files[1])
+	result, err := v8client.Eval("script.js", "__svelte__ + 2")
+	if err != nil {
+		return err
+	}
+	fmt.Println(result)
+	appFile := extrafile.Load("APP")
+	listener, err := socket.From(appFile[0])
+	if err != nil {
+		return err
+	}
+	fmt.Println("got listener", listener)
+	return nil
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/scripts/test-v8-pipe/main.go
+++ b/scripts/test-v8-pipe/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/livebud/bud/internal/extrafile"
+
+	"github.com/livebud/bud/package/exe"
+
+	"github.com/livebud/bud/package/js/v8server"
+)
+
+func run(ctx context.Context) error {
+	r1, w2, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	// defer w2.Close()
+	r2, w1, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	// defer w1.Close()
+	v8Server := v8server.New(r1, w1)
+	go func() {
+		fmt.Println("err serving", v8Server.Serve())
+	}()
+
+	cmd := exe.Command(ctx, "go", "run", "scripts/test-v8-pipe/child/main.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	extrafile.Inject(&cmd.ExtraFiles, &cmd.Env, "V8", r2, w2)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR improves how file descriptors are passed through the system. 

The main goal of this PR was to add support for passing render requests through OS pipes instead of through a spawned bud binary. This makes testing a bit easier.