### PR TITLE
.github/workflows: update CI to use the main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       # Temporary fix to get the tests working until we pass the V8 client as a
       # os.Pipe
       - name: Install bud binary into $PATH
-        run: go install github.com/livebud/bud@v8pipe2
+        run: go install github.com/livebud/bud@main
 
       - name: Install bud node_modules
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
 
       # Temporary fix to get the tests working until we pass the V8 client as a
       # os.Pipe
+      # Using GOPRIVATE=* to try and force Go to install the latest from the
+      # main branch. See: https://github.com/golang/go/issues/53226
       - name: Install bud binary into $PATH
         run: GOPRIVATE=* go install github.com/livebud/bud@main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       # Temporary fix to get the tests working until we pass the V8 client as a
       # os.Pipe
       - name: Install bud binary into $PATH
-        run: go install github.com/livebud/bud@main
+        run: GOPRIVATE=* go install github.com/livebud/bud@main
 
       - name: Install bud node_modules
         run: npm ci


### PR DESCRIPTION
Update CI to use the main branch now after changing it from `bud js v8 client` to `bud js v8 serve`