### PR TITLE
Fix testdir flakiness

### DIFF
--- a/internal/testdir/testdir.go
+++ b/internal/testdir/testdir.go
@@ -173,6 +173,9 @@ func (d *Dir) mapfs() (fstest.MapFS, error) {
 		}
 		hashes = append(hashes, []byte(hash)...)
 	}
+	if len(formatted) == 0 {
+		return nil, fmt.Errorf("testdir: empty go.mod for some reason")
+	}
 	mapfs["go.mod"] = &fstest.MapFile{
 		Data:    formatted,
 		ModTime: time.Now(),

--- a/internal/testdir/testdir.go
+++ b/internal/testdir/testdir.go
@@ -173,9 +173,6 @@ func (d *Dir) mapfs() (fstest.MapFS, error) {
 		}
 		hashes = append(hashes, []byte(hash)...)
 	}
-	if len(formatted) == 0 {
-		return nil, fmt.Errorf("testdir: empty go.mod for some reason")
-	}
 	mapfs["go.mod"] = &fstest.MapFile{
 		Data:    formatted,
 		ModTime: time.Now(),

--- a/runtime/generator/view/view_test.go
+++ b/runtime/generator/view/view_test.go
@@ -43,6 +43,7 @@ func TestHello(t *testing.T) {
 	is.In(res.Body().String(), "<h1>hello</h1>")
 	is.NoErr(td.Exists("bud/.app/view/view.go"))
 	// Change svelte file
+	td = testdir.New(dir)
 	td.Files["view/index.svelte"] = `<h1>hi</h1>`
 	is.NoErr(td.Write(ctx))
 	// Wait for the change event

--- a/runtime/generator/view/view_test.go
+++ b/runtime/generator/view/view_test.go
@@ -61,7 +61,7 @@ func TestHello(t *testing.T) {
 		`)
 	is.In(res.Body().String(), "<h1>hi</h1>")
 	is.Equal(stdout.String(), "")
-	is.In(stderr.String(), "info: Ready on")
+	is.Equal(stderr.String(), "")
 }
 
 // Note: if this test is failing due to context deadline exceeding, you
@@ -114,5 +114,5 @@ func TestHelloEmbed(t *testing.T) {
 	`)
 	is.In(res.Body().String(), "<h1>hello</h1>")
 	is.Equal(stdout.String(), "")
-	is.In(stderr.String(), "")
+	is.Equal(stderr.String(), "")
 }


### PR DESCRIPTION
Occasionally seeing the following error in CI:

```
error: conjure: generate "bud/.app/main.go". conjure: generate "bud/.app/program/program.go". program: unable to wire. di: unable to wire "app.com/bud/program".loadApp function. di: unable to find module for dependency "app.com/bud/.app/controller".*IndexAction . mod: missing module statement in "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/TestHello4050871875/001/go.mod", received ""
```

It seems like there's a case where `go.mod` is sometimes emptied. 