### PR TITLE
Watch dedupe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1
 	github.com/armon/go-radix v1.0.0
+	github.com/bep/debounce v1.2.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/evanw/esbuild v0.14.11
 	github.com/fatih/structtag v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x0
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/package/watcher/watcher.go
+++ b/package/watcher/watcher.go
@@ -38,7 +38,6 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 		duplicates[stamp] = struct{}{}
 		return false
 	}
-	_ = isDuplicate
 	gitIgnore := gitignore.From(dir)
 	// Files to ignore while walking the directory
 	shouldIgnore := func(path string, de fs.DirEntry) error {

--- a/package/watcher/watcher.go
+++ b/package/watcher/watcher.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"golang.org/x/sync/errgroup"
 
@@ -23,6 +24,21 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 		return err
 	}
 	defer watcher.Close()
+	// Avoid duplicate events
+	duplicates := map[string]struct{}{}
+	isDuplicate := func(path string, stat fs.FileInfo) bool {
+		stamp, err := computeStamp(path, stat)
+		if err != nil {
+			return false
+		}
+		// Duplicate check
+		if _, ok := duplicates[stamp]; ok {
+			return true
+		}
+		duplicates[stamp] = struct{}{}
+		return false
+	}
+	_ = isDuplicate
 	gitIgnore := gitignore.From(dir)
 	// Files to ignore while walking the directory
 	shouldIgnore := func(path string, de fs.DirEntry) error {
@@ -54,6 +70,14 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 			return fn(path)
 		}
 	}
+	seen := map[string]struct{}{}
+	hasSeen := func(path string) bool {
+		if _, ok := seen[path]; ok {
+			return true
+		}
+		seen[path] = struct{}{}
+		return false
+	}
 	// For some reason renames are often emitted instead of
 	// Remove. Check it and correct.
 	rename := func(path string) error {
@@ -63,6 +87,10 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 		}
 		// If it's a different error, ignore
 		if !errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		// Don't do anything if we've already seen this path
+		if hasSeen(path) {
 			return nil
 		}
 		// Remove the path and emit an update
@@ -76,6 +104,10 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 	// Remove the file or directory from the watcher.
 	// We intentionally ignore errors for this case.
 	remove := func(path string) error {
+		// Don't do anything if we've already seen this path
+		if hasSeen(path) {
+			return nil
+		}
 		watcher.Remove(path)
 		// Trigger an update
 		if err := fn(path); err != nil {
@@ -88,11 +120,17 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 	// If a new directory is created, add and trigger all the files within
 	// that directory.
 	create := func(path string) error {
+		// Reset seen path
+		delete(seen, path)
+		// Stat the file
 		stat, err := os.Stat(path)
 		if err != nil {
 			return nil
 		}
 		if gitIgnore(path, stat.IsDir()) {
+			return nil
+		}
+		if isDuplicate(path, stat) {
 			return nil
 		}
 		err = watcher.Add(path)
@@ -115,11 +153,17 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 	}
 	// A file or directory has been updated. Notify our matchers.
 	write := func(path string) error {
-		fi, err := os.Stat(path)
+		// Reset seen path
+		delete(seen, path)
+		// Stat the file
+		stat, err := os.Stat(path)
 		if err != nil {
 			return nil
 		}
-		if gitIgnore(path, fi.IsDir()) {
+		if gitIgnore(path, stat.IsDir()) {
+			return nil
+		}
+		if isDuplicate(path, stat) {
 			return nil
 		}
 		// Trigger an update
@@ -178,4 +222,14 @@ func Watch(ctx context.Context, dir string, fn func(path string) error) error {
 		return nil
 	}
 	return nil
+}
+
+// computeStamp uses path, size, mode and modtime to try and ensure this is a
+// unique event.
+func computeStamp(path string, stat fs.FileInfo) (stamp string, err error) {
+	mtime := stat.ModTime().UnixNano()
+	mode := stat.Mode()
+	size := stat.Size()
+	stamp = path + ":" + strconv.Itoa(int(size)) + ":" + mode.String() + ":" + strconv.Itoa(int(mtime))
+	return stamp, nil
 }

--- a/package/watcher/watcher.go
+++ b/package/watcher/watcher.go
@@ -31,17 +31,21 @@ func newPathSet() *pathSet {
 	}
 }
 
+// pathset is used to collect paths that have changed and flush them all at once
+// when the watch function is triggered.
 type pathSet struct {
 	mu    sync.RWMutex
 	paths map[string]struct{}
 }
 
+// Add a path to the set
 func (p *pathSet) Add(path string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.paths[path] = struct{}{}
 }
 
+// Flush the stored paths and clear the path set.
 func (p *pathSet) Flush() (paths []string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/package/watcher/watcher_test.go
+++ b/package/watcher/watcher_test.go
@@ -194,16 +194,10 @@ func TestWithScaffold(t *testing.T) {
 	is.True(paths["view"])
 	is.True(paths["view/index.svelte"])
 	is.True(paths["view/show.svelte"])
-	// While there should be no more events, testing this can be flaky in CI.
-	// Instead test that we don't have any events with unexpected paths.
-	// An extra event isn't the end of the world, it'll just reload one more time.
+	// Test that there's no more events in the pipe
 	select {
 	case path := <-event:
-		rel, err := filepath.Rel(dir, path)
-		is.NoErr(err)
-		if _, ok := paths[rel]; !ok {
-			t.Fatalf("unexpected event: %q", path)
-		}
+		t.Fatalf("unexpected event: %q", path)
 	case <-time.Tick(waitForEvents):
 	}
 	cancel()

--- a/package/watcher/watcher_test.go
+++ b/package/watcher/watcher_test.go
@@ -32,12 +32,12 @@ func writeFiles(dir string, files map[string]string) error {
 	return eg.Wait()
 }
 
-func getEvent(event <-chan string) (string, error) {
+func getEvent(event <-chan []string) ([]string, error) {
 	select {
-	case path := <-event:
-		return path, nil
+	case paths := <-event:
+		return paths, nil
 	case <-time.After(1 * time.Second):
-		return "", errors.New("timed out while waiting for watcher")
+		return nil, errors.New("timed out while waiting for watcher")
 	}
 }
 
@@ -49,13 +49,14 @@ func TestChange(t *testing.T) {
 	})
 	is.NoErr(err)
 	ctx := context.Background()
-	event := make(chan string, 1)
+	event := make(chan []string)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
-		return watcher.Watch(ctx, dir, func(path string) error {
+		return watcher.Watch(ctx, dir, func(paths []string) error {
 			select {
-			case event <- path:
+			case event <- paths:
 			case <-ctx.Done():
 			}
 			return nil
@@ -64,9 +65,10 @@ func TestChange(t *testing.T) {
 	time.Sleep(waitForEvents)
 	err = os.WriteFile(filepath.Join(dir, "a.txt"), []byte("b"), 0644)
 	is.NoErr(err)
-	path, err := getEvent(event)
+	paths, err := getEvent(event)
 	is.NoErr(err)
-	is.Equal(path, filepath.Join(dir, "a.txt"))
+	is.Equal(len(paths), 1)
+	is.Equal(paths[0], filepath.Join(dir, "a.txt"))
 	cancel()
 	is.NoErr(eg.Wait())
 }
@@ -79,13 +81,14 @@ func TestDelete(t *testing.T) {
 	})
 	is.NoErr(err)
 	ctx := context.Background()
-	event := make(chan string, 1)
+	event := make(chan []string)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
-		return watcher.Watch(ctx, dir, func(path string) error {
+		return watcher.Watch(ctx, dir, func(paths []string) error {
 			select {
-			case event <- path:
+			case event <- paths:
 			case <-ctx.Done():
 			}
 			return nil
@@ -94,9 +97,10 @@ func TestDelete(t *testing.T) {
 	time.Sleep(waitForEvents)
 	err = os.RemoveAll(filepath.Join(dir, "a.txt"))
 	is.NoErr(err)
-	path, err := getEvent(event)
+	paths, err := getEvent(event)
 	is.NoErr(err)
-	is.Equal(path, filepath.Join(dir, "a.txt"))
+	is.Equal(len(paths), 1)
+	is.Equal(paths[0], filepath.Join(dir, "a.txt"))
 	cancel()
 	is.NoErr(eg.Wait())
 }
@@ -105,13 +109,14 @@ func TestCreate(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	ctx := context.Background()
-	event := make(chan string, 1)
+	event := make(chan []string)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
-		return watcher.Watch(ctx, dir, func(path string) error {
+		return watcher.Watch(ctx, dir, func(paths []string) error {
 			select {
-			case event <- path:
+			case event <- paths:
 			case <-ctx.Done():
 			}
 			return nil
@@ -120,9 +125,10 @@ func TestCreate(t *testing.T) {
 	time.Sleep(waitForEvents)
 	err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("b"), 0644)
 	is.NoErr(err)
-	path, err := getEvent(event)
+	paths, err := getEvent(event)
 	is.NoErr(err)
-	is.Equal(path, filepath.Join(dir, "a.txt"))
+	is.Equal(len(paths), 1)
+	is.Equal(paths[0], filepath.Join(dir, "a.txt"))
 	cancel()
 	is.NoErr(eg.Wait())
 }
@@ -131,13 +137,14 @@ func TestCreateRecursive(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	ctx := context.Background()
-	event := make(chan string, 1)
+	event := make(chan []string)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
-		return watcher.Watch(ctx, dir, func(path string) error {
+		return watcher.Watch(ctx, dir, func(paths []string) error {
 			select {
-			case event <- path:
+			case event <- paths:
 			case <-ctx.Done():
 			}
 			return nil
@@ -146,14 +153,13 @@ func TestCreateRecursive(t *testing.T) {
 	time.Sleep(waitForEvents)
 	err := os.MkdirAll(filepath.Join(dir, "b"), 0755)
 	is.NoErr(err)
-	path, err := getEvent(event)
-	is.NoErr(err)
-	is.Equal(path, filepath.Join(dir, "b"))
 	err = os.WriteFile(filepath.Join(dir, "b", "a.txt"), []byte("b"), 0644)
 	is.NoErr(err)
-	path, err = getEvent(event)
+	paths, err := getEvent(event)
 	is.NoErr(err)
-	is.Equal(path, filepath.Join(dir, "b", "a.txt"))
+	is.Equal(len(paths), 2)
+	is.Equal(paths[0], filepath.Join(dir, "b"))
+	is.Equal(paths[1], filepath.Join(dir, "b/a.txt"))
 	cancel()
 	is.NoErr(eg.Wait())
 }
@@ -162,13 +168,14 @@ func TestWithScaffold(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	ctx := context.Background()
-	event := make(chan string, 4)
+	event := make(chan []string)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
-		return watcher.Watch(ctx, dir, func(path string) error {
+		return watcher.Watch(ctx, dir, func(paths []string) error {
 			select {
-			case event <- path:
+			case event <- paths:
 			case <-ctx.Done():
 			}
 			return nil
@@ -181,23 +188,18 @@ func TestWithScaffold(t *testing.T) {
 		"view/show.svelte":         `<h1>show</h1>`,
 	})
 	is.NoErr(err)
-	paths := map[string]bool{}
-	for i := 1; i <= 5; i++ {
-		path, err := getEvent(event)
-		is.NoErr(err)
-		rel, err := filepath.Rel(dir, path)
-		is.NoErr(err)
-		paths[rel] = true
-	}
-	is.True(paths["controller"])
-	is.True(paths["controller/controller.go"])
-	is.True(paths["view"])
-	is.True(paths["view/index.svelte"])
-	is.True(paths["view/show.svelte"])
-	// Test that there's no more events in the pipe
+	paths, err := getEvent(event)
+	is.NoErr(err)
+	is.Equal(len(paths), 5)
+	is.Equal(paths[0], filepath.Join(dir, "controller"))
+	is.Equal(paths[1], filepath.Join(dir, "controller/controller.go"))
+	is.Equal(paths[2], filepath.Join(dir, "view"))
+	is.Equal(paths[3], filepath.Join(dir, "view/index.svelte"))
+	is.Equal(paths[4], filepath.Join(dir, "view/show.svelte"))
+	// Test that there's only been one event
 	select {
-	case path := <-event:
-		t.Fatalf("unexpected event: %q", path)
+	case <-event:
+		t.Fatalf("unexpected extra event")
 	case <-time.Tick(waitForEvents):
 	}
 	cancel()

--- a/scripts/test-watcher/main.go
+++ b/scripts/test-watcher/main.go
@@ -18,8 +18,8 @@ func run(ctx context.Context) error {
 		return err
 	}
 	ctx = sig.Trap(ctx, os.Interrupt)
-	return watcher.Watch(ctx, dirname, func(path string) error {
-		fmt.Println("-> triggered", path)
+	return watcher.Watch(ctx, dirname, func(paths []string) error {
+		fmt.Println("-> triggered", paths)
 		return nil
 	})
 }

--- a/scripts/test-watcher/main.go
+++ b/scripts/test-watcher/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/livebud/bud/internal/current"
+
+	"github.com/livebud/bud/internal/sig"
+	"github.com/livebud/bud/package/watcher"
+)
+
+func run(ctx context.Context) error {
+	dirname, err := current.Directory()
+	if err != nil {
+		return err
+	}
+	ctx = sig.Trap(ctx, os.Interrupt)
+	return watcher.Watch(ctx, dirname, func(path string) error {
+		fmt.Println("-> triggered", path)
+		return nil
+	})
+}
+
+func main() {
+	ctx := context.Background()
+	if err := run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
- Dedupe events on linux: stamp each file mentioned in a watch event and compare them with previously seen events
- Improve remove events: sometimes remove events fire before the file has been removed. This was causing the remove function not to trigger. Now we trigger a single remove event regardless whether it's still on disk or not.
- Tighten up tests again: I loosened one of the watch tests to allow for duplicate events to avoid flaky CI. I tightened them up again now that we're deduping.
- Group events within 20ms into a single event with a debounce function: Ideally scaffolding many files should only trigger one change event after all the files have been created.

Closes: https://github.com/livebud/bud/pull/88
Closes: #123