### PR TITLE
internal/cli: ensure alignment between CLI and runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ go.fmt:
 go.install:
 	@ go build --trimpath \
 		--ldflags="-s -w \
-			-X 'github.com/livebud/bud/internal/versions.Bud=0.1.5' \
+			-X 'github.com/livebud/bud/internal/versions.Bud=latest' \
 		" \
 		-o /usr/local/bin/bud \
 		.

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ go.fmt:
 go.install:
 	@ go build --trimpath \
 		--ldflags="-s -w \
-			-X 'github.com/livebud/bud/internal/version.Bud=latest' \
+			-X 'github.com/livebud/bud/internal/versions.Bud=0.1.5' \
 		" \
 		-o /usr/local/bin/bud \
 		.
@@ -91,7 +91,7 @@ go.build.darwin.amd64:
 		--out=bud \
 		--trimpath \
 		--ldflags="-s -w \
-			-X 'github.com/livebud/bud/internal/version.Bud=$(BUD_VERSION)' \
+			-X 'github.com/livebud/bud/internal/versions.Bud=$(BUD_VERSION)' \
 		" \
 		./ 1> /dev/null
 	@ mkdir -p release/bud_v$(BUD_VERSION)_darwin_amd64
@@ -108,7 +108,7 @@ go.build.darwin.arm64:
 		--out=bud \
 		--trimpath \
 		--ldflags="-s -w \
-			-X 'github.com/livebud/bud/internal/version.Bud=$(BUD_VERSION)' \
+			-X 'github.com/livebud/bud/internal/versions.Bud=$(BUD_VERSION)' \
 		" \
 		./ 1> /dev/null
 	@ mkdir -p release/bud_v$(BUD_VERSION)_darwin_arm64
@@ -124,7 +124,7 @@ go.build.linux:
 		--out=bud \
 		--trimpath \
 		--ldflags="-s -w \
-			-X 'github.com/livebud/bud/internal/version.Bud=$(BUD_VERSION)' \
+			-X 'github.com/livebud/bud/internal/versions.Bud=$(BUD_VERSION)' \
 		" \
 		./ 1> /dev/null
 	@ mkdir -p release/bud_v$(BUD_VERSION)_linux_amd64
@@ -145,7 +145,7 @@ go.build.windows:
 		--out=bud \
 		--trimpath \
 		--ldflags="-s -w \
-			-X 'github.com/livebud/bud/internal/version.Bud=$(BUD_VERSION)' \
+			-X 'github.com/livebud/bud/internal/versions.Bud=$(BUD_VERSION)' \
 		" \
 		./ 1> /dev/null
 

--- a/internal/cli/create/create.go
+++ b/internal/cli/create/create.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/livebud/bud/internal/current"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 	"github.com/livebud/bud/package/gomod"
 	"github.com/otiai10/copy"
 )
@@ -70,7 +70,7 @@ func (c *Command) Run(ctx context.Context) error {
 	// TODO: clean this mess up.
 	// It's breaking out of the packagejson.go file, but moving symlinks via
 	// os.Rename doesn't seem to work.
-	if version.Bud == "latest" {
+	if versions.Bud == "latest" {
 		npm, err := exec.LookPath("npm")
 		if err != nil {
 			return err

--- a/internal/cli/create/gomod.go
+++ b/internal/cli/create/gomod.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 
 	"github.com/Bowery/prompt"
 	"github.com/livebud/bud/internal/gotemplate"
@@ -55,11 +55,11 @@ func (c *Command) generateGoMod(ctx context.Context, dir string) error {
 	// Get the Go version
 	state.Version = strings.TrimPrefix(goVersion(runtime.Version()), "go")
 	// Add the required dependencies
-	if version.Bud != "latest" {
+	if versions.Bud != "latest" {
 		state.Requires = []*Require{
 			{
 				Import:  "github.com/livebud/bud",
-				Version: "v" + version.Bud,
+				Version: "v" + versions.Bud,
 			},
 		}
 	} else {

--- a/internal/cli/create/packagejson.go
+++ b/internal/cli/create/packagejson.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 )
 
 func (c *Command) generatePackageJSON(ctx context.Context, dir, name string) error {
@@ -23,8 +23,8 @@ func (c *Command) generatePackageJSON(ctx context.Context, dir, name string) err
 	state.Name = name
 	state.Private = true
 	state.Dependencies = map[string]string{
-		"livebud": version.Bud,
-		"svelte":  version.Svelte,
+		"livebud": versions.Bud,
+		"svelte":  versions.Svelte,
 	}
 	code, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 )
 
 type Command struct {
@@ -16,19 +16,19 @@ type Command struct {
 func (c *Command) Run(ctx context.Context) error {
 	switch c.Key {
 	case "bud":
-		fmt.Println(version.Bud)
+		fmt.Println(versions.Bud)
 		return nil
 	case "svelte":
-		fmt.Println(version.Svelte)
+		fmt.Println(versions.Svelte)
 		return nil
 	case "react":
-		fmt.Println(version.React)
+		fmt.Println(versions.React)
 		return nil
 	default:
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.AlignRight)
-		tw.Write([]byte("bud: \t" + version.Bud + "\n"))
-		tw.Write([]byte("svelte: \t" + version.Svelte + "\n"))
-		tw.Write([]byte("react: \t" + version.React + "\n"))
+		tw.Write([]byte("bud: \t" + versions.Bud + "\n"))
+		tw.Write([]byte("svelte: \t" + versions.Svelte + "\n"))
+		tw.Write([]byte("react: \t" + versions.React + "\n"))
 		return tw.Flush()
 	}
 }

--- a/internal/imhash/imhash.go
+++ b/internal/imhash/imhash.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 
 	"github.com/cespare/xxhash"
 	"golang.org/x/sync/errgroup"
@@ -190,7 +190,7 @@ func shouldWalk(module *gomod.Module, importPath string) bool {
 		return true
 	}
 	// Search livebud if we're in development, otherwise skip it
-	if version.Bud == "latest" && strings.HasPrefix(importPath, "github.com/livebud/bud") {
+	if versions.Bud == "latest" && strings.HasPrefix(importPath, "github.com/livebud/bud") {
 		return true
 	}
 	return false

--- a/internal/testdir/testdir_test.go
+++ b/internal/testdir/testdir_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 )
 
 func TestDir(t *testing.T) {
@@ -21,7 +21,7 @@ func TestDir(t *testing.T) {
 	td.Modules["github.com/livebud/bud-test-plugin"] = "v0.0.2"
 	td.Files["controller/controller.go"] = `package controller`
 	td.BFiles["public/favicon.ico"] = []byte{0x00}
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.NodeModules["livebud"] = "*"
 	is.NoErr(td.Write(ctx))
 	is.NoErr(td.Exists(
@@ -49,7 +49,7 @@ func TestRefresh(t *testing.T) {
 	td.Modules["github.com/livebud/bud-test-plugin"] = "v0.0.2"
 	td.Files["controller/controller.go"] = `package controller`
 	td.BFiles["public/favicon.ico"] = []byte{0x00}
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.NodeModules["livebud"] = "*"
 	is.NoErr(td.Write(ctx))
 	is.NoErr(td.Exists(

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -1,4 +1,4 @@
-package version
+package versions
 
 // Bud gets changed at link time using ldflags.
 var Bud = "latest"

--- a/package/gomod/file.go
+++ b/package/gomod/file.go
@@ -25,8 +25,14 @@ func (f *File) AddRequire(importPath, version string) error {
 	return f.file.AddRequire(importPath, version)
 }
 
-func (f *File) Replace(oldPath, newPath string) error {
-	return f.AddReplace(oldPath, "", newPath, "")
+// Replace finds a replaced package within go.mod or returns nil if not found.
+func (f *File) Replace(path string) *module.Version {
+	for _, rep := range f.file.Replace {
+		if rep.Old.Path == path {
+			return &rep.Old
+		}
+	}
+	return nil
 }
 
 func (f *File) AddReplace(oldPath, oldVers, newPath, newVers string) error {

--- a/runtime/generator/controller/controller_test.go
+++ b/runtime/generator/controller/controller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/livebud/bud/internal/cli/testcli"
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 )
 
 func TestIndexString(t *testing.T) {
@@ -1238,7 +1238,7 @@ func TestViewUnnamed(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	td := testdir.New(dir)
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.Files["view/index.svelte"] = `
 		<script>
 			export let users = []
@@ -1386,7 +1386,7 @@ func TestViewNestedUnnamed(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	td := testdir.New(dir)
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.Files["view/users/index.svelte"] = `
 		<script>
 			export let users = []
@@ -1534,7 +1534,7 @@ func TestViewDeepUnnamed(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	td := testdir.New(dir)
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.Files["view/teams/users/index.svelte"] = `
 		<script>
 			export let onlineUsers = []
@@ -1834,7 +1834,7 @@ func TestEmptyActionWithView(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	td := testdir.New(dir)
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.Files["controller/controller.go"] = `
 		package controller
 		type Controller struct {}

--- a/runtime/generator/view/view_test.go
+++ b/runtime/generator/view/view_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/livebud/bud/internal/cli/testcli"
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 	"github.com/matthewmueller/diff"
 )
 
@@ -24,7 +24,7 @@ func TestHello(t *testing.T) {
 		func (c *Controller) Index() string { return "" }
 	`
 	td.Files["view/index.svelte"] = `<h1>hello</h1>`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.NodeModules["livebud"] = "*"
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(cli.New(dir))
@@ -78,7 +78,7 @@ func TestHelloEmbed(t *testing.T) {
 		func (c *Controller) Index() string { return "" }
 	`
 	td.Files["view/index.svelte"] = `<h1>hello</h1>`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	td.NodeModules["livebud"] = "*"
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(cli.New(dir))

--- a/runtime/view/dom/dom_test.go
+++ b/runtime/view/dom/dom_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 	v8 "github.com/livebud/bud/package/js/v8"
 	"github.com/livebud/bud/package/svelte"
 	"github.com/livebud/bud/runtime/view/dom"
@@ -89,7 +89,7 @@ func TestNodeModules(t *testing.T) {
 	dir := t.TempDir()
 	td := testdir.New(dir)
 	td.Files["view/index.svelte"] = `<h1>hi world</h1>`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	is.NoErr(td.Write(ctx))
 	module, err := gomod.Find(dir)
 	is.NoErr(err)
@@ -111,7 +111,7 @@ func TestGenerateDir(t *testing.T) {
 	td.Files["view/index.svelte"] = `<h1>index</h1>`
 	td.Files["view/about/index.svelte"] = `<h2>about</h2>`
 	td.NodeModules["livebud"] = "*"
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	is.NoErr(td.Write(ctx))
 	vm, err := v8.Load()
 	is.NoErr(err)

--- a/runtime/view/ssr/ssr_test.go
+++ b/runtime/view/ssr/ssr_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/js"
 	v8 "github.com/livebud/bud/package/js/v8"
@@ -28,7 +28,7 @@ func TestSvelteHello(t *testing.T) {
 	dir := t.TempDir()
 	td := testdir.New(dir)
 	td.Files["view/index.svelte"] = `<h1>hi world</h1>`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	is.NoErr(td.Write(ctx))
 	vm, err := v8.Load()
 	is.NoErr(err)
@@ -83,7 +83,7 @@ func TestSvelteAwait(t *testing.T) {
 			{/await}
 		</div>
 	`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	is.NoErr(td.Write(ctx))
 	vm, err := v8.Load()
 	is.NoErr(err)
@@ -174,7 +174,7 @@ func TestSvelteProps(t *testing.T) {
 		</script>
 		<h6>{@html JSON.stringify(comment)}</h6>
 	`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	is.NoErr(td.Write(ctx))
 	vm, err := v8.Load()
 	is.NoErr(err)
@@ -281,7 +281,7 @@ func TestSvelteLocalImports(t *testing.T) {
 			<Comment {comment} />
 		{/each}
 	`
-	td.NodeModules["svelte"] = version.Svelte
+	td.NodeModules["svelte"] = versions.Svelte
 	is.NoErr(td.Write(ctx))
 	vm, err := v8.Load()
 	is.NoErr(err)

--- a/scripts/set-package-json/main.go
+++ b/scripts/set-package-json/main.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/livebud/bud/internal/npm"
-	"github.com/livebud/bud/internal/version"
+	"github.com/livebud/bud/internal/versions"
 	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/log/console"
 )
@@ -25,21 +25,21 @@ func run() error {
 	}
 	// Update the dependencies in ./livebud/package.json
 	if err := npm.Set(filepath.Join(dir, "livebud"), map[string]string{
-		"dependencies.svelte":              version.Svelte,
-		"dependencies.react":               version.React,
-		"dependencies.react-dom":           version.React,
-		"devDependencies.@types/react":     version.React,
-		"devDependencies.@types/react-dom": version.React,
+		"dependencies.svelte":              versions.Svelte,
+		"dependencies.react":               versions.React,
+		"dependencies.react-dom":           versions.React,
+		"devDependencies.@types/react":     versions.React,
+		"devDependencies.@types/react-dom": versions.React,
 	}); err != nil {
 		return err
 	}
 	// Update the dependencies in .
 	if err := npm.Set(dir, map[string]string{
-		"devDependencies.svelte":           version.Svelte,
-		"devDependencies.react":            version.React,
-		"devDependencies.react-dom":        version.React,
-		"devDependencies.@types/react":     version.React,
-		"devDependencies.@types/react-dom": version.React,
+		"devDependencies.svelte":           versions.Svelte,
+		"devDependencies.react":            versions.React,
+		"devDependencies.react-dom":        versions.React,
+		"devDependencies.@types/react":     versions.React,
+		"devDependencies.@types/react-dom": versions.React,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/livebud/bud/issues/125.

Also,

- internal/version: rename package to versions to avoid overlap with the internal/cli/version package.