### PR TITLE
support HandlerFunc actions

### DIFF
--- a/runtime/generator/controller/controller.gotext
+++ b/runtime/generator/controller/controller.gotext
@@ -90,6 +90,9 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpReq
 	{{- else }}
 	fn := {{$.Name}}.{{$action.Name}}
 	{{- end }}
+	{{- if $action.HandlerFunc }}
+	return http.HandlerFunc(fn)
+	{{- else }}
 	// Call the controller
 	{{ $action.Results.Set }}fn(
 		{{- range $param := $action.Params }}
@@ -127,6 +130,7 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpReq
 		JSON: response.Status(204),
 		{{- end }}
 	}
+	{{- end }}
 }
 {{- end }}
 

--- a/runtime/generator/controller/state.go
+++ b/runtime/generator/controller/state.go
@@ -51,6 +51,7 @@ type Action struct {
 	Method      string
 	Context     *Context
 	Params      []*ActionParam
+	HandlerFunc bool
 	Input       string
 	Results     ActionResults
 	RespondJSON bool


### PR DESCRIPTION
As discussed in #143: if an action matches the `http.HandlerFunc` signature, use it directly. Route parameters are available in `r.URL.Query()`, and a test covers that as well.

Let me know if anything else is needed here!