### PR TITLE
framework/controller: don't load imports for action results. closes #137

### DIFF
--- a/framework/controller/controller_test.go
+++ b/framework/controller/controller_test.go
@@ -1911,3 +1911,32 @@ func TestEnvSupport(t *testing.T) {
 	`)
 	is.NoErr(app.Close())
 }
+
+func TestStructInStruct(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["model/post/post.go"] = `
+		package post
+		type Model struct {}
+	`
+	td.Files["controller/controller.go"] = `
+		package controller
+		import "context"
+		import "app.com/model/post"
+		type Controller struct {}
+		type Post struct {
+			Model post.Model
+		}
+		func (c *Controller) Show(ctx context.Context, id int) (post *Post, err error) {
+			return &Post{}, nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	result, err := cli.Run(ctx, "build")
+	is.NoErr(err)
+	is.Equal(result.Stdout(), "")
+	is.Equal(result.Stderr(), "")
+}

--- a/framework/controller/loader.go
+++ b/framework/controller/loader.go
@@ -412,13 +412,9 @@ func (l *loader) loadActionResultFields(result *parser.Result, def parser.Declar
 		l.Bail(fmt.Errorf("controller: unable to find struct for %s", result.Type()))
 	}
 	for _, field := range stct.PublicFields() {
-		def, err := field.Definition()
-		if err != nil {
-			l.Bail(fmt.Errorf("controller: unable to load definition for field %s in %s . %w", field.Name(), result.Name(), err))
-		}
 		fields = append(fields, &ActionResultField{
 			Name: field.Name(),
-			Type: l.loadType(field.Type(), def),
+			Type: field.Type().String(),
 		})
 	}
 	return fields


### PR DESCRIPTION
I'm not 100% sure this is the right answer. Imports were needed for params, but all the tests pass without importing results. 

Rather than trying to come up with failing cases, let's just see if anything pops up and we'll then know we need to be more nuanced.

**Update:** looking at the template, the generated code never dives into the result set, so this should work.