### PR TITLE
framework/controller: support a controller loader with an error result. fixes #101.

### DIFF
--- a/framework/controller/loader.go
+++ b/framework/controller/loader.go
@@ -515,6 +515,7 @@ func (l *loader) loadContext(controller *Controller, method *parser.Function) *C
 				Import: importPath,
 				Type:   recv.Type().String(),
 			},
+			&di.Error{},
 		},
 		Params: []di.Dependency{
 			di.ToType("net/http", "ResponseWriter"),


### PR DESCRIPTION
Prior to this PR, controllers couldn't have loaders that could return an error result. This PR fixes that constraint.