### PR TITLE
framework/controller: add rudimentary redirects on form submissions that have errors

### DIFF
--- a/example/hn/controller/sessions/sessions.go
+++ b/example/hn/controller/sessions/sessions.go
@@ -1,0 +1,13 @@
+package sessions
+
+import "fmt"
+
+type Controller struct {
+}
+
+func (c *Controller) New() {
+}
+
+func (c *Controller) Create(email, password string) error {
+	return fmt.Errorf("not done yet")
+}

--- a/example/hn/go.mod
+++ b/example/hn/go.mod
@@ -3,7 +3,7 @@ module github.com/livebud/bud/example/hn
 go 1.17
 
 require (
-	github.com/livebud/bud v0.0.0
+	github.com/livebud/bud v0.1.11
 	github.com/matthewmueller/hackernews v0.3.0
 )
 

--- a/example/hn/view/sessions/new.svelte
+++ b/example/hn/view/sessions/new.svelte
@@ -1,0 +1,24 @@
+<form action="/sessions" method="post">
+  <h1>Login</h1>
+
+  <label for="email">
+    <h2>Email Address</h2>
+    <input type="text" name="email" />
+  </label>
+  <label for="password">
+    <h2>Password</h2>
+    <input type="password" name="password" />
+  </label>
+  <p>
+    <input type="submit" value="Signup" />
+  </p>
+</form>
+
+<style>
+  form {
+    padding: 20px;
+  }
+  h2 {
+    margin: 10px 0;
+  }
+</style>

--- a/framework/controller/controller.gotext
+++ b/framework/controller/controller.gotext
@@ -65,6 +65,9 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpReq
 	// Unmarshal the request body
 	if err := request.Unmarshal(httpRequest, &in); err != nil {
 		return &response.Format{
+			{{- if ne $action.Method "GET" }}
+			HTML: response.Status(http.StatusSeeOther).RedirectBack(httpRequest.URL.Path),
+			{{- end }}
 			JSON: response.Status(400).Set("Content-Type", "application/json").JSON(map[string]string{"error": err.Error()}),
 		}
 	}
@@ -82,6 +85,9 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpReq
 	{{- if $action.Context.Results.Error }}
 	if {{ $action.Context.Results.Error }} != nil {
 		return &response.Format{
+			{{- if ne $action.Method "GET" }}
+			HTML: response.Status(http.StatusSeeOther).RedirectBack(httpRequest.URL.Path),
+			{{- end }}
 			JSON: response.Status(500).Set("Content-Type", "application/json").JSON(map[string]string{"error": {{ $action.Context.Results.Error }}.Error()}),
 		}
 	}
@@ -102,6 +108,9 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpReq
 	{{- if $action.Results.Error }}
 	if {{ $action.Results.Error }} != nil {
 		return &response.Format{
+			{{- if ne $action.Method "GET" }}
+			HTML: response.Status(http.StatusSeeOther).RedirectBack(httpRequest.URL.Path),
+			{{- end }}
 			JSON: response.Status(500).Set("Content-Type", "application/json").JSON(map[string]string{"error": {{ $action.Results.Error }}.Error()}),
 		}
 	}

--- a/framework/controller/controllerrt/response/response.go
+++ b/framework/controller/controllerrt/response/response.go
@@ -50,7 +50,7 @@ func (res *Response) Set(key, value string) *Response {
 	return res
 }
 
-// Redirect to url
+// Redirect to path
 func (res *Response) Redirect(path string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Attach all preset headers
@@ -64,6 +64,18 @@ func (res *Response) Redirect(path string) http.Handler {
 		}
 		// Redirect the response
 		http.Redirect(w, r, path, res.status)
+	})
+}
+
+// RedirectBack tries using the referrer to redirect to the previous page.
+// If the referrer isn't set, it uses the fallback path.
+func (res *Response) RedirectBack(fallback string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.Referer()
+		if path == "" {
+			path = fallback
+		}
+		res.Redirect(path).ServeHTTP(w, r)
 	})
 }
 

--- a/internal/cli/bud/bud.go
+++ b/internal/cli/bud/bud.go
@@ -21,6 +21,7 @@ import (
 	"github.com/livebud/bud/package/commander"
 	"github.com/livebud/bud/package/di"
 	"github.com/livebud/bud/package/gomod"
+	"github.com/livebud/bud/package/js"
 	v8 "github.com/livebud/bud/package/js/v8"
 	"github.com/livebud/bud/package/log"
 	"github.com/livebud/bud/package/log/console"
@@ -121,12 +122,8 @@ func FileSystem(log log.Interface, module *gomod.Module, flag *framework.Flag) (
 	return genfs, nil
 }
 
-func FileServer(log log.Interface, module *gomod.Module, flag *framework.Flag) (*overlay.Server, error) {
+func FileServer(log log.Interface, module *gomod.Module, vm js.VM, flag *framework.Flag) (*overlay.Server, error) {
 	servefs, err := overlay.Serve(log, module)
-	if err != nil {
-		return nil, err
-	}
-	vm, err := v8.Load()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/livebud/bud/internal/cli/create"
 	"github.com/livebud/bud/internal/cli/newcontroller"
 	"github.com/livebud/bud/internal/cli/run"
+	"github.com/livebud/bud/internal/cli/toolbs"
 	"github.com/livebud/bud/internal/cli/toolcache"
 	"github.com/livebud/bud/internal/cli/tooldi"
 	"github.com/livebud/bud/internal/cli/toolfscat"
@@ -82,6 +83,15 @@ func (c *CLI) Run(ctx context.Context, args ...string) error {
 
 	{ // $ bud tool
 		cli := cli.Command("tool", "extra tools")
+
+		{ // $ bud tool bs
+			cmd := toolbs.New(cmd, c.in)
+			cli := cli.Command("bs", "run the bud server")
+			cli.Flag("embed", "embed assets").Bool(&cmd.Flag.Embed).Default(false)
+			cli.Flag("hot", "hot reloading").Bool(&cmd.Flag.Hot).Default(true)
+			cli.Flag("minify", "minify assets").Bool(&cmd.Flag.Minify).Default(false)
+			cli.Run(cmd.Run)
+		}
 
 		{ // $ bud tool di
 			cmd := tooldi.New(cmd, c.in)

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -94,8 +94,13 @@ func (c *Command) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	// Load V8
+	vm, err := v8.Load()
+	if err != nil {
+		return err
+	}
 	// Load the file server
-	servefs, err := bud.FileServer(log, module, c.Flag)
+	servefs, err := bud.FileServer(log, module, vm, c.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/testcli/testcli.go
+++ b/internal/cli/testcli/testcli.go
@@ -271,7 +271,7 @@ func coerceMimes(res *http.Response) error {
 	return nil
 }
 
-func (c *Client) Request(req *http.Request) (*Response, error) {
+func (c *Client) Do(req *http.Request) (*Response, error) {
 	res, err := c.webc.Do(req)
 	if err != nil {
 		return nil, err
@@ -323,81 +323,97 @@ func (c *Client) Ready(ctx context.Context) error {
 
 func (c *Client) Get(path string) (*Response, error) {
 	c.log.Debug("testcli: get request", "path", path)
-	req, err := http.NewRequest(http.MethodGet, getURL(path), nil)
+	req, err := c.GetRequest(path)
 	if err != nil {
 		return nil, err
 	}
-	return c.Request(req)
+	return c.Do(req)
 }
 
 func (c *Client) GetJSON(path string) (*Response, error) {
 	c.log.Debug("testcli: get json request", "path", path)
-	req, err := http.NewRequest(http.MethodGet, getURL(path), nil)
+	req, err := c.GetRequest(path)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	return c.Request(req)
+	return c.Do(req)
+}
+
+func (c *Client) GetRequest(path string) (*http.Request, error) {
+	return http.NewRequest(http.MethodGet, getURL(path), nil)
 }
 
 func (c *Client) Post(path string, body io.Reader) (*Response, error) {
 	c.log.Debug("testcli: post request", "path", path)
-	req, err := http.NewRequest(http.MethodPost, getURL(path), body)
+	req, err := c.PostRequest(path, body)
 	if err != nil {
 		return nil, err
 	}
-	return c.Request(req)
+	return c.Do(req)
 }
 
 func (c *Client) PostJSON(path string, body io.Reader) (*Response, error) {
 	c.log.Debug("testcli: post json request", "path", path)
-	req, err := http.NewRequest(http.MethodPost, getURL(path), body)
+	req, err := c.PostRequest(path, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	return c.Request(req)
+	return c.Do(req)
+}
+
+func (c *Client) PostRequest(path string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(http.MethodPost, getURL(path), body)
 }
 
 func (c *Client) Patch(path string, body io.Reader) (*Response, error) {
 	c.log.Debug("testcli: patch request", "path", path)
-	req, err := http.NewRequest(http.MethodPatch, getURL(path), body)
+	req, err := c.PatchRequest(path, body)
 	if err != nil {
 		return nil, err
 	}
-	return c.Request(req)
+	return c.Do(req)
 }
 
 func (c *Client) PatchJSON(path string, body io.Reader) (*Response, error) {
 	c.log.Debug("testcli: patch json request", "path", path)
-	req, err := http.NewRequest(http.MethodPatch, getURL(path), body)
+	req, err := c.PatchRequest(path, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	return c.Request(req)
+	return c.Do(req)
+}
+
+func (c *Client) PatchRequest(path string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(http.MethodPatch, getURL(path), body)
 }
 
 func (c *Client) Delete(path string, body io.Reader) (*Response, error) {
 	c.log.Debug("testcli: delete request", "path", path)
-	req, err := http.NewRequest(http.MethodDelete, getURL(path), body)
+	req, err := c.DeleteRequest(path, body)
 	if err != nil {
 		return nil, err
 	}
-	return c.Request(req)
+	return c.Do(req)
 }
 
 func (c *Client) DeleteJSON(path string, body io.Reader) (*Response, error) {
 	c.log.Debug("testcli: delete json request", "path", path)
-	req, err := http.NewRequest(http.MethodDelete, getURL(path), body)
+	req, err := c.DeleteRequest(path, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	return c.Request(req)
+	return c.Do(req)
+}
+
+func (c *Client) DeleteRequest(path string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(http.MethodDelete, getURL(path), body)
 }
 
 type Response struct {

--- a/internal/cli/toolbs/toolbs.go
+++ b/internal/cli/toolbs/toolbs.go
@@ -1,0 +1,57 @@
+package toolbs
+
+import (
+	"context"
+
+	"github.com/livebud/bud/framework/web/webrt"
+	"github.com/livebud/bud/package/budserver"
+	v8 "github.com/livebud/bud/package/js/v8"
+	"github.com/livebud/bud/package/socket"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/cli/bud"
+	"github.com/livebud/bud/internal/pubsub"
+)
+
+func New(bud *bud.Command, in *bud.Input) *Command {
+	return &Command{
+		bud:  bud,
+		in:   in,
+		Flag: new(framework.Flag),
+	}
+}
+
+type Command struct {
+	bud  *bud.Command
+	in   *bud.Input
+	Flag *framework.Flag
+}
+
+func (c *Command) Run(ctx context.Context) error {
+	log, err := bud.Log(c.in.Stdout, c.bud.Log)
+	if err != nil {
+		return err
+	}
+	module, err := bud.Module(c.bud.Dir)
+	if err != nil {
+		return err
+	}
+	vm, err := v8.Load()
+	if err != nil {
+		return err
+	}
+	// Load the file server
+	servefs, err := bud.FileServer(log, module, vm, c.Flag)
+	if err != nil {
+		return err
+	}
+	bus := pubsub.New()
+	server := budserver.New(servefs, bus, log, vm)
+	budln, err := socket.Listen(":35729")
+	if err != nil {
+		return err
+	}
+	defer budln.Close()
+	log.Info("Listening on http://127.0.0.1:35729")
+	return webrt.Serve(ctx, budln, server)
+}


### PR DESCRIPTION
This PR will use the `Referer` to redirect back when your form encounters an error during submission. It doesn't return the errors back yet, that will require sessions and flash messages.

Also,

- internal/cli/toolbs: add tool for running bud server so you can run your generated main.go without re-generating the bud/ directory.