### PR TITLE
internal/cli/create: fix typo in scaffolding .gitignore

### DIFF
--- a/internal/cli/create/create.go
+++ b/internal/cli/create/create.go
@@ -161,7 +161,7 @@ func (c *Command) Scaffold(state *State) error {
 	// Scaffold into that directory
 	if err := scaffold.Scaffold(scaffold.OSFS(c.absDir),
 		scaffold.Template("go.mod", gomod, state.Module),
-		scaffold.Template("gitignore", gitignore, nil),
+		scaffold.Template(".gitignore", gitignore, nil),
 		scaffold.JSON("package.json", state.Package),
 	); err != nil {
 		return err

--- a/internal/cli/create/create_test.go
+++ b/internal/cli/create/create_test.go
@@ -2,7 +2,6 @@ package create_test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/livebud/bud/internal/cli/testcli"
@@ -30,9 +29,15 @@ func TestCreateOutsideGoPathModulePath(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
+	td := testdir.New(dir)
 	cli := testcli.New(dir)
-	result, err := cli.Run(ctx, "create", "--module=github.com/my/app", filepath.Join(dir, "app"))
+	is.NoErr(td.NotExists(".gitignore"))
+	result, err := cli.Run(ctx, "create", "--module=github.com/my/app", dir)
 	is.NoErr(err)
 	is.Equal(result.Stdout(), "")
 	is.Equal(result.Stderr(), "")
+	is.NoErr(td.Exists(".gitignore"))
+	is.NoErr(td.Exists("go.sum"))
+	is.NoErr(td.Exists("package.json"))
+	is.NoErr(td.Exists("package-lock.json"))
 }


### PR DESCRIPTION
`bud create` had a typo where it scaffolded `gitignore` not `.gitignore`. This PR fixes that.