### PR TITLE
fix minor spelling error in output

### DIFF
--- a/framework/transform/transformrt/transform.go
+++ b/framework/transform/transformrt/transform.go
@@ -181,7 +181,7 @@ func (t *transformer) Plugins() (plugins []esbuild.Plugin) {
 	for from, to := range t.pathmap {
 		from := from
 		plugins = append(plugins, esbuild.Plugin{
-			Name: "tranform_" + strings.TrimPrefix(from, ".") + "_to_" + strings.TrimPrefix(to, "."),
+			Name: "transform_" + strings.TrimPrefix(from, ".") + "_to_" + strings.TrimPrefix(to, "."),
 			Setup: func(epb esbuild.PluginBuild) {
 				// Load svelte files. Add import if not present
 				epb.OnLoad(esbuild.OnLoadOptions{Filter: `\` + from + `$`}, func(args esbuild.OnLoadArgs) (result esbuild.OnLoadResult, err error) {


### PR DESCRIPTION
I changed the word "tranform" to the word "transform". I noticed the error while inspecting the code in order to learn more about how the framework works.