### PR TITLE
Feature/check golang version

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/livebud/bud/internal/cli/bud"
 	"github.com/livebud/bud/internal/cli/build"
 	"github.com/livebud/bud/internal/cli/create"
+	"github.com/livebud/bud/internal/cli/goversion"
 	"github.com/livebud/bud/internal/cli/newcontroller"
 	"github.com/livebud/bud/internal/cli/run"
 	"github.com/livebud/bud/internal/cli/toolbs"
@@ -30,7 +33,20 @@ type CLI struct {
 	in *bud.Input
 }
 
+var REQUIRED_GO_VERSION = goversion.NewVersion(1, 18, 0)
+
 func (c *CLI) Run(ctx context.Context, args ...string) error {
+
+	currentGoVersion := goversion.CurrentVersion()
+	if currentGoVersion.CompareTo(REQUIRED_GO_VERSION) < 0 {
+		
+		fmt.Printf("Current go version '%s' is less than required '%s'.",
+			currentGoVersion.ToString(), REQUIRED_GO_VERSION.ToString())
+		fmt.Println()
+		
+		os.Exit(1)
+	}
+	
 	// $ bud [args...]
 	cmd := bud.New(c.in)
 	cli := commander.New("bud").Writer(c.in.Stdout)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"os"
 
 	"github.com/livebud/bud/internal/cli/bud"
@@ -38,7 +39,10 @@ var REQUIRED_GO_VERSION = goversion.NewVersion(1, 18, 0)
 func (c *CLI) Run(ctx context.Context, args ...string) error {
 
 	currentGoVersion := goversion.CurrentVersion()
-	if currentGoVersion.CompareTo(REQUIRED_GO_VERSION) < 0 {
+	if currentGoVersion.IsValid() {
+		fmt.Printf("Non-standard go version '%s' returned, cannot ensure compliance.",
+			runtime.Version())
+	} else if currentGoVersion.CompareTo(REQUIRED_GO_VERSION) < 0 {
 		
 		fmt.Printf("Current go version '%s' is less than required '%s'.",
 			currentGoVersion.ToString(), REQUIRED_GO_VERSION.ToString())

--- a/internal/cli/goversion/goversion.go
+++ b/internal/cli/goversion/goversion.go
@@ -1,0 +1,99 @@
+
+package goversion
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Represents the version of golang
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// Returns a version from the given 3 integers in the format
+// <major>.<minor>.<patch>.
+func NewVersion(major, minor, patch int) Version {
+	return Version{major, minor, patch}
+}
+
+// CurrentVersion builds and returns a Version object from the string
+// returned by runtime.Version().
+func CurrentVersion() Version {
+	
+	versionString := runtime.Version() // something like "go1.18.3"
+	if !strings.HasPrefix(versionString, "go") {
+		// version might be a hash or something, can't compare
+		return Version{} // 0.0.0
+	}
+	// trim to semver version like "1.18.3" or possibly "1.18"
+	semverString := strings.Replace(versionString, "go", "", 1)
+	versionSlice := strings.Split(semverString, ".") // ["1", "18", "3"]
+	
+	version := Version{}
+	
+	if len(versionSlice) >= 1 {
+		major, err := strconv.Atoi(versionSlice[0])
+		if err != nil {
+			return Version{}
+		}
+		version.Major = major // 1
+	}
+	if len(versionSlice) >= 2 {
+		minor, err := strconv.Atoi(versionSlice[1])
+		if err != nil {
+			return Version{}
+		}
+		version.Minor = minor // 2
+	}
+	if len(versionSlice) >= 3 {
+		patch, err := strconv.Atoi(versionSlice[2])
+		if err != nil {
+			return Version{}
+		}
+		version.Patch = patch
+	}
+	
+	return version
+}
+
+// CompareTo returns a negative integer
+// if the version is less than the other. It returns a positive integer
+// if the version is greater than the other. It returns 0 if both versions
+// are the same.
+func (v Version) CompareTo(other Version) int {
+	
+	majorComparison := v.Major - other.Major
+	if majorComparison != 0 {
+		return majorComparison
+	}
+	
+	minorComparison := v.Minor - other.Minor
+	if minorComparison != 0 {
+		return minorComparison
+	}
+	
+	patchComparison := v.Patch - other.Patch
+	if patchComparison != 0 {
+		return patchComparison
+	}
+	
+	return 0
+}
+
+// IsValid returns true if the version is > 0.0.0.
+func (v Version) IsValid() bool {
+	if v.Major <= 0 && v.Minor <= 0 && v.Patch <= 0 {
+		return false
+	}
+	return true
+}
+
+// ToString returns a string like "<major>.<minor>.<patch>".
+func (v Version) ToString() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}


### PR DESCRIPTION

I'm not sure if this is the best way of doing this or not.

This is related to issue #45 .

I added a small package with a representation of the version returned by `runtime.Version()`, including a way to compare versions. This is checked at the beginning of handling CLI input.

If the running version is less than the hard-coded required version, then a message is printed and the process stops. If the version returned was a commit hash or anything other than a normal version of go, then the process continues after a warning message.