### PR TITLE
Renaming or deleting views should trigger a recompile

### DIFF
--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -276,7 +276,7 @@ func catchError(
 // canIncrementallyReload returns true if we can incrementally reload a page
 func canIncrementallyReload(events []watcher.UpdateEvent) bool {
 	for _, event := range events {
-		if event.EventType != watcher.ChangeEventType &&
+		if event.EventType != watcher.EditEventType &&
 			isViewFile(event.Path) {
 			return false
 		}

--- a/package/watcher/watcher.go
+++ b/package/watcher/watcher.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ChangeEventType = iota
+	EditEventType = iota
 	CreateEventType
 	RenameEventType
 	RemoveEventType
@@ -192,7 +192,7 @@ func Watch(ctx context.Context, dir string, fn func([]UpdateEvent) error) error 
 			return nil
 		}
 		// Trigger an update
-		trigger(path, ChangeEventType)
+		trigger(path, EditEventType)
 		return nil
 	}
 

--- a/package/watcher/watcher.go
+++ b/package/watcher/watcher.go
@@ -64,7 +64,6 @@ func (u *UpdateSet) Flush() []UpdateEvent {
 	for path := range u.updates {
 		updates = append(updates, UpdateEvent{path, u.updates[path]})
 	}
-	//sort.Strings(paths)
 	u.updates = make(map[string]int)
 	return updates
 }

--- a/package/watcher/watcher_test.go
+++ b/package/watcher/watcher_test.go
@@ -68,7 +68,7 @@ func TestChange(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(len(events), 1)
 	is.Equal(events[0].Path, filepath.Join(dir, "a.txt"))
-	is.Equal(events[0].EventType, ChangeEventType)
+	is.Equal(events[0].EventType, EditEventType)
 	cancel()
 	is.NoErr(eg.Wait())
 }


### PR DESCRIPTION
Refactored watcher to include type of change event. Non-edit changes to view files triggers an app restart.

Addresses issue https://github.com/livebud/bud/issues/138