### PR TITLE
makefile: add tools to install script. closes #215

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install:
 	go mod tidy
 	npm install
 	(cd livebud && npm install)
+	$(MAKE) go.tools
 	$(MAKE) go.generate
 
 ##


### PR DESCRIPTION
A slightly better approach would be to modify:

https://github.com/livebud/bud/blob/3a251081b908bc8c2dd15cfcaac0352b03e59f82/internal/urlx/parse.go#L13

To use `go run github.com/pointlander/peg`, but currently it generates a header comment that would change every time.

E.g.
```
// Code generated by /var/folders/4f/tcxcr6_55v9bp38d8g4hjlf80000gn/T/go-build1073813380/b001/exe/peg
```