### PR TITLE
internal/cli/tool*: support -C chdir support

### DIFF
--- a/internal/cli/toolfsls/toolfsls.go
+++ b/internal/cli/toolfsls/toolfsls.go
@@ -32,7 +32,8 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	module, err := bud.Module(c.Dir)
+	dir := path.Clean(c.Dir)
+	module, err := bud.Module(path.Join(c.bud.Dir, dir))
 	if err != nil {
 		return err
 	}
@@ -41,7 +42,6 @@ func (c *Command) Run(ctx context.Context) error {
 		return err
 	}
 	defer close()
-	dir := path.Clean(c.Dir)
 	des, err := fs.ReadDir(fsys, dir)
 	if err != nil {
 		return err

--- a/internal/cli/toolfstxtar/toolfstxtar.go
+++ b/internal/cli/toolfstxtar/toolfstxtar.go
@@ -33,7 +33,8 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	module, err := bud.Module(c.Dir)
+	dir := path.Clean(c.Dir)
+	module, err := bud.Module(path.Join(c.bud.Dir, dir))
 	if err != nil {
 		return err
 	}
@@ -43,7 +44,6 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 	defer close()
 	ar := new(txtar.Archive)
-	dir := path.Clean(c.Dir)
 	err = fs.WalkDir(fsys, dir, func(path string, de fs.DirEntry, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
Prior to this PR, `-C` was ignored for the following commands

```sh
bud -C example/basic tool fs ls
bud -C example/basic tool fs txtar
```

Now it's respected. Discovered this while working on #244.

