### PR TITLE
don't trigger generators with stat() or filler dir's readdir()

### DIFF
--- a/internal/virtual/direntry.go
+++ b/internal/virtual/direntry.go
@@ -2,15 +2,11 @@ package virtual
 
 import (
 	"io/fs"
-	"time"
 )
 
 type DirEntry struct {
 	Path    string
-	Mode    fs.FileMode
-	ModTime time.Time
-	Sys     interface{}
-	Size    int64
+	ModeDir bool
 }
 
 var _ fs.DirEntry = (*DirEntry)(nil)
@@ -20,19 +16,19 @@ func (e *DirEntry) Name() string {
 }
 
 func (e *DirEntry) IsDir() bool {
-	return e.Mode&fs.ModeDir != 0
+	return e.ModeDir
 }
 
 func (e *DirEntry) Type() fs.FileMode {
-	return e.Mode
+	if e.ModeDir {
+		return fs.ModeDir
+	}
+	return 0
 }
 
 func (e *DirEntry) Info() (fs.FileInfo, error) {
-	return &fileInfo{
-		path:    e.Path,
-		mode:    e.Mode,
-		modTime: e.ModTime,
-		sys:     e.Sys,
-		size:    e.Size,
+	return &FileInfo{
+		Path:    e.Path,
+		ModeDir: e.ModeDir,
 	}, nil
 }

--- a/internal/virtual/file.go
+++ b/internal/virtual/file.go
@@ -3,17 +3,13 @@ package virtual
 import (
 	"io"
 	"io/fs"
-	"time"
 )
 
 // File struct
 type File struct {
-	Path    string
-	Data    []byte
-	Mode    fs.FileMode
-	ModTime time.Time
-	Sys     interface{}
-	offset  int64
+	Path   string
+	Data   []byte
+	offset int64
 }
 
 var _ io.ReadSeeker = (*File)(nil)
@@ -37,12 +33,9 @@ func (f *File) Read(b []byte) (int, error) {
 }
 
 func (f *File) Stat() (fs.FileInfo, error) {
-	return &fileInfo{
-		path:    f.Path,
-		mode:    f.Mode &^ fs.ModeDir,
-		modTime: f.ModTime,
-		size:    int64(len(f.Data)),
-		sys:     f.Sys,
+	return &FileInfo{
+		Path:    f.Path,
+		ModeDir: false,
 	}, nil
 }
 
@@ -64,11 +57,8 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 
 func (f *File) Open() fs.File {
 	return &File{
-		Path:    f.Path,
-		Data:    f.Data,
-		Mode:    f.Mode,
-		ModTime: f.ModTime,
-		Sys:     f.Sys,
-		offset:  0, // reset offset
+		Path:   f.Path,
+		Data:   f.Data,
+		offset: 0, // reset offset
 	}
 }

--- a/internal/virtual/fileinfo.go
+++ b/internal/virtual/fileinfo.go
@@ -6,20 +6,30 @@ import (
 	"time"
 )
 
-// A fileInfo implements fs.FileInfo and fs.DirEntry for a given map file.
-type fileInfo struct {
-	path    string
-	size    int64
-	mode    fs.FileMode
-	modTime time.Time
-	sys     interface{}
+// FileInfo implements fs.FileInfo and fs.DirEntry for a given map file.
+type FileInfo struct {
+	Path    string
+	ModeDir bool
 }
 
-func (i *fileInfo) Name() string               { return path.Base(i.path) }
-func (i *fileInfo) Mode() fs.FileMode          { return i.mode }
-func (i *fileInfo) Type() fs.FileMode          { return i.mode.Type() }
-func (i *fileInfo) ModTime() time.Time         { return i.modTime }
-func (i *fileInfo) IsDir() bool                { return i.mode&fs.ModeDir != 0 }
-func (i *fileInfo) Sys() interface{}           { return i.sys }
-func (i *fileInfo) Info() (fs.FileInfo, error) { return i, nil }
-func (i *fileInfo) Size() int64                { return i.size }
+var _ fs.FileInfo = (*FileInfo)(nil)
+var _ fs.DirEntry = (*FileInfo)(nil)
+
+var zero time.Time
+
+const unknownSize = -1
+
+func (i *FileInfo) Name() string               { return path.Base(i.Path) }
+func (i *FileInfo) Type() fs.FileMode          { return i.Mode() }
+func (i *FileInfo) ModTime() time.Time         { return zero }
+func (i *FileInfo) IsDir() bool                { return i.ModeDir }
+func (i *FileInfo) Sys() interface{}           { return nil }
+func (i *FileInfo) Info() (fs.FileInfo, error) { return i, nil }
+func (i *FileInfo) Size() int64                { return unknownSize }
+
+func (i *FileInfo) Mode() fs.FileMode {
+	if i.ModeDir {
+		return fs.ModeDir
+	}
+	return 0
+}

--- a/internal/virtual/from.go
+++ b/internal/virtual/from.go
@@ -21,10 +21,7 @@ func From(file fs.File) (entry Entry, err error) {
 
 func fromDir(file fs.File, stat fs.FileInfo) (entry Entry, err error) {
 	vdir := &Dir{
-		Path:    stat.Name(),
-		ModTime: stat.ModTime(),
-		Mode:    stat.Mode(),
-		Sys:     stat.Sys(),
+		Path: stat.Name(),
 	}
 	if dir, ok := file.(fs.ReadDirFile); ok {
 		des, err := dir.ReadDir(-1)
@@ -32,16 +29,9 @@ func fromDir(file fs.File, stat fs.FileInfo) (entry Entry, err error) {
 			return nil, err
 		}
 		for _, de := range des {
-			fi, err := de.Info()
-			if err != nil {
-				return nil, err
-			}
 			vdir.Entries = append(vdir.Entries, &DirEntry{
 				Path:    de.Name(),
-				ModTime: fi.ModTime(),
-				Mode:    fi.Mode(),
-				Sys:     fi.Sys(),
-				Size:    fi.Size(),
+				ModeDir: de.IsDir(),
 			})
 		}
 	}
@@ -55,10 +45,7 @@ func fromFile(file fs.File, stat fs.FileInfo) (entry Entry, err error) {
 		return nil, err
 	}
 	return &File{
-		Path:    stat.Name(),
-		Data:    data,
-		ModTime: stat.ModTime(),
-		Mode:    stat.Mode(),
-		Sys:     stat.Sys(),
+		Path: stat.Name(),
+		Data: data,
 	}, nil
 }

--- a/internal/virtual/json.go
+++ b/internal/virtual/json.go
@@ -3,7 +3,6 @@ package virtual
 import (
 	"encoding/json"
 	"io/fs"
-	"time"
 )
 
 func MarshalJSON(file fs.File) ([]byte, error) {
@@ -17,32 +16,23 @@ func MarshalJSON(file fs.File) ([]byte, error) {
 type jsonEntry struct {
 	Path    string
 	Data    []byte
-	Mode    fs.FileMode
-	ModTime time.Time
-	Sys     interface{}
 	Entries []*DirEntry
 }
 
 func (f *jsonEntry) Open() fs.File {
-	if f.Mode.IsDir() {
+	if f.Entries != nil {
 		entries := make([]fs.DirEntry, len(f.Entries))
 		for i, entry := range f.Entries {
 			entries[i] = entry
 		}
 		return &Dir{
 			Path:    f.Path,
-			Mode:    f.Mode,
-			ModTime: f.ModTime,
-			Sys:     f.Sys,
 			Entries: entries,
 		}
 	}
 	return &File{
-		Path:    f.Path,
-		Data:    f.Data,
-		Mode:    f.Mode,
-		ModTime: f.ModTime,
-		Sys:     f.Sys,
+		Path: f.Path,
+		Data: f.Data,
 	}
 }
 

--- a/package/budfs/genfs/genfs_test.go
+++ b/package/budfs/genfs/genfs_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
-	"time"
 
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/package/budfs/genfs"
@@ -193,7 +192,7 @@ func TestAll(t *testing.T) {
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.ModeDir)
 	is.Equal(fi.Name(), "bud")
-	is.Equal(fi.Size(), int64(0))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 	stat, err := file.Stat()
 	is.NoErr(err)
@@ -201,7 +200,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// Stat .
 	stat, err = fs.Stat(gen, ".")
@@ -210,7 +209,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// ReadDir .
 	des, err = fs.ReadDir(gen, ".")
@@ -237,7 +236,7 @@ func TestAll(t *testing.T) {
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.ModeDir)
 	is.Equal(fi.Name(), "view")
-	is.Equal(fi.Size(), int64(0))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 	stat, err = file.Stat()
 	is.NoErr(err)
@@ -245,7 +244,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// Stat bud
 	stat, err = fs.Stat(gen, "bud")
@@ -254,7 +253,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// ReadDir bud
 	des, err = fs.ReadDir(gen, "bud")
@@ -281,7 +280,7 @@ func TestAll(t *testing.T) {
 	is.Equal(fi.IsDir(), true)
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.ModeDir)
-	is.Equal(fi.Size(), int64(0))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 	is.Equal(des[1].Name(), "index.svelte")
 	is.Equal(des[1].IsDir(), false)
@@ -292,7 +291,7 @@ func TestAll(t *testing.T) {
 	is.Equal(fi.IsDir(), false)
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.FileMode(0))
-	is.Equal(fi.Size(), int64(14))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 	stat, err = file.Stat()
 	is.NoErr(err)
@@ -300,7 +299,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// Stat bud
 	stat, err = fs.Stat(gen, "bud/view")
@@ -309,7 +308,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// ReadDir bud
 	des, err = fs.ReadDir(gen, "bud/view")
@@ -324,7 +323,7 @@ func TestAll(t *testing.T) {
 	is.Equal(fi.IsDir(), true)
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.ModeDir)
-	is.Equal(fi.Size(), int64(0))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 	is.Equal(des[1].Name(), "index.svelte")
 	is.Equal(des[1].IsDir(), false)
@@ -335,7 +334,7 @@ func TestAll(t *testing.T) {
 	is.Equal(fi.IsDir(), false)
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.FileMode(0))
-	is.Equal(fi.Size(), int64(14))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 
 	// bud/view/about
@@ -355,7 +354,7 @@ func TestAll(t *testing.T) {
 	is.Equal(fi.IsDir(), false)
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.FileMode(0))
-	is.Equal(fi.Size(), int64(14))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 	stat, err = file.Stat()
 	is.NoErr(err)
@@ -363,7 +362,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// Stat bud
 	stat, err = fs.Stat(gen, "bud/view/about")
@@ -372,7 +371,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.ModeDir)
 	is.True(stat.IsDir())
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(0))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// ReadDir bud
 	des, err = fs.ReadDir(gen, "bud/view/about")
@@ -387,7 +386,7 @@ func TestAll(t *testing.T) {
 	is.Equal(fi.IsDir(), false)
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.FileMode(0))
-	is.Equal(fi.Size(), int64(14))
+	is.Equal(fi.Size(), int64(-1))
 	is.Equal(fi.Sys(), nil)
 
 	// bud/view/index.svelte
@@ -400,7 +399,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(14))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// Stat
 	stat, err = fs.Stat(gen, "bud/view/index.svelte")
@@ -409,7 +408,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(14))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// ReadFile
 	code, err := fs.ReadFile(gen, "bud/view/index.svelte")
@@ -426,7 +425,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(14))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// Stat
 	stat, err = fs.Stat(gen, "bud/view/about/about.svelte")
@@ -435,7 +434,7 @@ func TestAll(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(14))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	// ReadFile
 	code, err = fs.ReadFile(gen, "bud/view/about/about.svelte")
@@ -541,7 +540,7 @@ func TestServeFile(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(29))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	code, err := fs.ReadFile(gen, "bud/view/_index.svelte")
 	is.NoErr(err)
@@ -556,7 +555,7 @@ func TestServeFile(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(35))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	code, err = fs.ReadFile(gen, "bud/view/about/_about.svelte")
 	is.NoErr(err)
@@ -892,7 +891,7 @@ func TestEmbedOpen(t *testing.T) {
 	is.Equal(string(code), `<h1>index</h1>`)
 	stat, err := fs.Stat(gen, "bud/view/index.svelte")
 	is.NoErr(err)
-	is.Equal(stat.ModTime(), time.Time{})
+	is.True(stat.ModTime().IsZero())
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 
@@ -902,7 +901,7 @@ func TestEmbedOpen(t *testing.T) {
 	is.Equal(string(code), `<h1>about</h1>`)
 	stat, err = fs.Stat(gen, "bud/view/about/about.svelte")
 	is.NoErr(err)
-	is.Equal(stat.ModTime(), time.Time{})
+	is.True(stat.ModTime().IsZero())
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 
@@ -912,7 +911,7 @@ func TestEmbedOpen(t *testing.T) {
 	is.Equal(string(code), `favicon.ico`)
 	stat, err = fs.Stat(gen, "bud/public/favicon.ico")
 	is.NoErr(err)
-	is.Equal(stat.ModTime(), time.Time{})
+	is.True(stat.ModTime().IsZero())
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 
@@ -986,7 +985,7 @@ func TestMount(t *testing.T) {
 	is.True(fi.ModTime().IsZero())
 	is.Equal(fi.Mode(), fs.FileMode(0))
 	is.Equal(fi.IsDir(), false)
-	is.Equal(fi.Size(), int64(16))
+	is.Equal(fi.Size(), int64(-1))
 	code, err := fs.ReadFile(gen, "bud/generator/tailwind/tailwind.css")
 	is.NoErr(err)
 	is.Equal(string(code), `/** tailwind **/`)
@@ -1042,18 +1041,6 @@ func TestFileAndDir(t *testing.T) {
 	is.Equal(string(code), "bud/node_modules/runtime/svelte")
 }
 
-func TestReadDirNotExists(t *testing.T) {
-	is := is.New(t)
-	// Add the view
-	gen := genfs.New()
-	gen.GenerateFile("bud/controller/controller.go", func(file *genfs.File) error {
-		return fs.ErrNotExist
-	})
-	des, err := fs.ReadDir(gen, "bud/controller")
-	is.NoErr(err)
-	is.Equal(len(des), 0)
-}
-
 func TestServeFileNative(t *testing.T) {
 	is := is.New(t)
 	gen := genfs.New()
@@ -1074,7 +1061,7 @@ func TestServeFileNative(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(29))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	code, err := fs.ReadFile(gen, "duo/view/_index.svelte")
 	is.NoErr(err)
@@ -1089,9 +1076,42 @@ func TestServeFileNative(t *testing.T) {
 	is.Equal(stat.Mode(), fs.FileMode(0))
 	is.Equal(stat.IsDir(), false)
 	is.True(stat.ModTime().IsZero())
-	is.Equal(stat.Size(), int64(35))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Sys(), nil)
 	code, err = fs.ReadFile(gen, "duo/view/about/_about.svelte")
 	is.NoErr(err)
 	is.Equal(string(code), `duo/view/about/_about.svelte's data`)
+}
+
+func TestStatNoGen(t *testing.T) {
+	is := is.New(t)
+	// Add the view
+	gen := genfs.New()
+	count := 0
+	gen.GenerateFile("bud/controller/controller.go", func(file *genfs.File) error {
+		count++
+		return fs.ErrNotExist
+	})
+	stat, err := fs.Stat(gen, "bud/controller/controller.go")
+	is.NoErr(err)
+	is.Equal(stat.Name(), "controller.go")
+	is.Equal(stat.Mode(), fs.FileMode(0))
+	is.Equal(stat.IsDir(), false)
+	is.True(stat.ModTime().IsZero())
+	is.Equal(stat.Size(), int64(-1))
+	is.Equal(stat.Sys(), nil)
+	is.Equal(count, 0)
+}
+
+func TestReadDirNoGen(t *testing.T) {
+	is := is.New(t)
+	// Add the view
+	gen := genfs.New()
+	gen.GenerateFile("bud/controller/controller.go", func(file *genfs.File) error {
+		return fs.ErrNotExist
+	})
+	// Readdir won't run the generator to know that the file doesn't exist
+	des, err := fs.ReadDir(gen, "bud/controller")
+	is.NoErr(err)
+	is.Equal(len(des), 1)
 }

--- a/package/budfs/treefs/fillerdir.go
+++ b/package/budfs/treefs/fillerdir.go
@@ -1,7 +1,6 @@
 package treefs
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 
@@ -24,18 +23,10 @@ func (f *fillerDir) Generate(target string) (fs.File, error) {
 	// TODO: run in parallel
 	for _, child := range children {
 		de := &dirEntry{child}
-		// Stat to ensure the file exists before adding it as a directory entry
-		if _, err := de.Info(); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			}
-			return nil, err
-		}
 		entries = append(entries, de)
 	}
 	return &virtual.Dir{
 		Path:    path,
-		Mode:    fs.ModeDir,
 		Entries: entries,
 	}, nil
 }

--- a/package/budhttp/client_test.go
+++ b/package/budhttp/client_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/livebud/bud/package/log/testlog"
 
@@ -143,9 +142,9 @@ func TestOpen(t *testing.T) {
 	stat, err := file.Stat()
 	is.NoErr(err)
 	is.Equal(stat.Name(), "_index.svelte.js")
-	is.Equal(stat.Size(), int64(3690))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Mode(), os.FileMode(0))
-	is.Equal(stat.ModTime(), time.Time{})
+	is.True(stat.ModTime().IsZero())
 	is.Equal(stat.IsDir(), false)
 	is.Equal(stat.Sys(), nil)
 
@@ -156,9 +155,9 @@ func TestOpen(t *testing.T) {
 	stat, err = file.Stat()
 	is.NoErr(err)
 	is.Equal(stat.Name(), "index.svelte")
-	is.Equal(stat.Size(), int64(3124))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Mode(), os.FileMode(0))
-	is.Equal(stat.ModTime(), time.Time{})
+	is.True(stat.ModTime().IsZero())
 	is.Equal(stat.IsDir(), false)
 	is.Equal(stat.Sys(), nil)
 
@@ -169,9 +168,9 @@ func TestOpen(t *testing.T) {
 	stat, err = file.Stat()
 	is.NoErr(err)
 	is.Equal(stat.Name(), "internal")
-	is.Equal(stat.Size(), int64(56452))
+	is.Equal(stat.Size(), int64(-1))
 	is.Equal(stat.Mode(), os.FileMode(0))
-	is.Equal(stat.ModTime(), time.Time{})
+	is.True(stat.ModTime().IsZero())
 	is.Equal(stat.IsDir(), false)
 	is.Equal(stat.Sys(), nil)
 }

--- a/package/remotefs/service.go
+++ b/package/remotefs/service.go
@@ -32,22 +32,14 @@ func (s *Service) Open(path string, vfile *fs.File) error {
 		}
 		entries := make([]fs.DirEntry, len(des))
 		for i, de := range des {
-			fi, err := de.Info()
-			if err != nil {
-				return err
-			}
 			entries[i] = &virtual.DirEntry{
 				Path:    de.Name(),
-				Mode:    de.Type(),
-				ModTime: fi.ModTime(),
-				Size:    fi.Size(),
+				ModeDir: de.IsDir(),
 			}
 		}
 		// Return a directory
 		*vfile = &virtual.Dir{
 			Path:    path,
-			ModTime: stat.ModTime(),
-			Mode:    stat.Mode(),
 			Entries: entries,
 		}
 		return nil
@@ -57,10 +49,8 @@ func (s *Service) Open(path string, vfile *fs.File) error {
 		return err
 	}
 	*vfile = &virtual.File{
-		Path:    path,
-		Data:    data,
-		ModTime: stat.ModTime(),
-		Mode:    stat.Mode(),
+		Path: path,
+		Data: data,
 	}
 	return nil
 }
@@ -71,16 +61,9 @@ func (s *Service) ReadDir(name string, vdes *[]fs.DirEntry) error {
 		return err
 	}
 	for _, de := range des {
-		stat, err := de.Info()
-		if err != nil {
-			return err
-		}
 		*vdes = append(*vdes, &virtual.DirEntry{
 			Path:    de.Name(),
-			Mode:    stat.Mode(),
-			ModTime: stat.ModTime(),
-			Sys:     stat.Sys(),
-			Size:    stat.Size(),
+			ModeDir: de.IsDir(),
 		})
 	}
 	return nil


### PR DESCRIPTION
This PR reduces the scope of the virtual filesystem in order to reduce the number of calls to the generator functions.

After this PR:

- `stat.Size()` will always return -1 for generators
- `stat.ModTime().IsZero()` will always be true for generators
- `fs.Stat(genfs, filepath)` won't call the underlying generate function
- `fs.ReadDir(genfs, somedir)` won't call the underlying generate function of the dir entries

This is a tradeoff, but I think it's going to be worth it. It will be more clear when generators run at the expense of being a less accurate filesystem. Surprisingly only a few of the tests failed and none of the framework tests failed after this change.