### PR TITLE
+1 to port if necessary

### DIFF
--- a/framework/app/app_test.go
+++ b/framework/app/app_test.go
@@ -2,11 +2,13 @@ package app_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/livebud/bud/internal/cli/testcli"
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
+	"github.com/livebud/bud/package/socket"
 )
 
 func TestWelcome(t *testing.T) {
@@ -29,4 +31,26 @@ func TestWelcome(t *testing.T) {
 	is.Equal(app.Stderr(), "")
 	is.NoErr(td.Exists("bud/app"))
 	is.NoErr(app.Close())
+}
+
+func TestOneUpPort(t *testing.T) {
+	is := is.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := socket.Listen(":3000")
+	is.NoErr(err)
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	is.NoErr(td.NotExists("bud/app"))
+	app, err := cli.Start(ctx, "run")
+	is.NoErr(err)
+	_, err = app.Get("/")
+	is.NoErr(err)
+	req, err := http.NewRequest("GET", "http://localhost:3000/", nil)
+	is.NoErr(err)
+	res, err := http.DefaultClient.Do(req)
+	is.NoErr(err)
+	defer res.Body.Close()
 }

--- a/framework/app/app_test.go
+++ b/framework/app/app_test.go
@@ -48,7 +48,7 @@ func TestOneUpPort(t *testing.T) {
 	is.NoErr(err)
 	_, err = app.Get("/")
 	is.NoErr(err)
-	req, err := http.NewRequest("GET", "http://localhost:3000/", nil)
+	req, err := http.NewRequest("GET", "http://localhost:3001/", nil)
 	is.NoErr(err)
 	res, err := http.DefaultClient.Do(req)
 	is.NoErr(err)

--- a/framework/app/app_test.go
+++ b/framework/app/app_test.go
@@ -2,13 +2,11 @@ package app_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/livebud/bud/internal/cli/testcli"
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testdir"
-	"github.com/livebud/bud/package/socket"
 )
 
 func TestWelcome(t *testing.T) {
@@ -31,26 +29,4 @@ func TestWelcome(t *testing.T) {
 	is.Equal(app.Stderr(), "")
 	is.NoErr(td.Exists("bud/app"))
 	is.NoErr(app.Close())
-}
-
-func TestOneUpPort(t *testing.T) {
-	is := is.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	_, err := socket.Listen(":3000")
-	is.NoErr(err)
-	dir := t.TempDir()
-	td := testdir.New(dir)
-	is.NoErr(td.Write(ctx))
-	cli := testcli.New(dir)
-	is.NoErr(td.NotExists("bud/app"))
-	app, err := cli.Start(ctx, "run")
-	is.NoErr(err)
-	_, err = app.Get("/")
-	is.NoErr(err)
-	req, err := http.NewRequest("GET", "http://localhost:3001/", nil)
-	is.NoErr(err)
-	res, err := http.DefaultClient.Do(req)
-	is.NoErr(err)
-	defer res.Body.Close()
 }

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -84,13 +84,18 @@ func (c *Command) Run(ctx context.Context) (err error) {
 		
 		listenAddress := c.Listen
 		webln, err = socket.Listen(listenAddress)
-		for err != nil {
+		for err != nil && listenPort < 65536 {
 			// increment port
 			listenPort = listenPort + 1
 			// reset listen address
 			listenAddress = fmt.Sprintf("%s:%d", parsedUrl.Hostname(), listenPort)
 			webln, err = socket.Listen(listenAddress)
 		}
+
+		if err != nil {
+			return err
+		}
+		
 		defer webln.Close()
 		log.Info("Listening on http://" + webln.Addr().String())
 	}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -2,12 +2,10 @@ package run
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/fs"
 	"net"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -20,7 +18,6 @@ import (
 	"github.com/livebud/bud/internal/gobuild"
 	"github.com/livebud/bud/internal/prompter"
 	"github.com/livebud/bud/internal/pubsub"
-	"github.com/livebud/bud/internal/urlx"
 	"github.com/livebud/bud/internal/versions"
 	"github.com/livebud/bud/package/budhttp/budsvr"
 	v8 "github.com/livebud/bud/package/js/v8"
@@ -73,29 +70,11 @@ func (c *Command) Run(ctx context.Context) (err error) {
 	// Listening on the web listener as soon as possible
 	webln := c.in.WebLn
 	if webln == nil {
-		parsedUrl, err := urlx.Parse(c.Listen)
+		// Listen and increment if the port is already in use up to 10 times
+		webln, err = socket.ListenUp(c.Listen, 10)
 		if err != nil {
 			return err
 		}
-		listenPort, err := strconv.Atoi(parsedUrl.Port())
-		if err != nil {
-			return err
-		}
-
-		listenAddress := c.Listen
-		webln, err = socket.Listen(listenAddress)
-		for err != nil && listenPort < 65536 {
-			// increment port
-			listenPort = listenPort + 1
-			// reset listen address
-			listenAddress = fmt.Sprintf("%s:%d", parsedUrl.Hostname(), listenPort)
-			webln, err = socket.Listen(listenAddress)
-		}
-
-		if err != nil {
-			return err
-		}
-
 		defer webln.Close()
 		log.Info("Listening on http://" + webln.Addr().String())
 	}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -81,7 +81,7 @@ func (c *Command) Run(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		
+
 		listenAddress := c.Listen
 		webln, err = socket.Listen(listenAddress)
 		for err != nil && listenPort < 65536 {
@@ -95,7 +95,7 @@ func (c *Command) Run(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		
+
 		defer webln.Close()
 		log.Info("Listening on http://" + webln.Addr().String())
 	}

--- a/package/socket/socket.go
+++ b/package/socket/socket.go
@@ -2,14 +2,20 @@ package socket
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/livebud/bud/internal/urlx"
 )
+
+// ErrAddrInUse occurs when a port is already in use
+var ErrAddrInUse = syscall.EADDRINUSE
 
 type Listener interface {
 	net.Listener
@@ -68,6 +74,41 @@ func Listen(path string) (Listener, error) {
 		return nil, err
 	}
 	return &listener{tcp}, nil
+}
+
+// ListenUp is similar to listen, but will increment the port number until it
+// finds a free one
+func ListenUp(path string, attempts int) (Listener, error) {
+	ln, err := Listen(path)
+	if err != nil {
+		if !errors.Is(err, ErrAddrInUse) {
+			return nil, err
+		}
+		if attempts--; attempts >= 0 {
+			newPath, err := incrementPort(path)
+			if err != nil {
+				return nil, err
+			}
+			return ListenUp(newPath, attempts-1)
+		}
+		return nil, err
+	}
+	return ln, nil
+}
+
+// Takes a address and increments the port by 1
+func incrementPort(path string) (string, error) {
+	url, err := urlx.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	port, err := strconv.Atoi(url.Port())
+	if err != nil {
+		return "", err
+	}
+	port++
+	url.Host = url.Hostname() + ":" + strconv.Itoa(port)
+	return url.String(), nil
 }
 
 // Dial creates a connection to an address

--- a/package/socket/socket.go
+++ b/package/socket/socket.go
@@ -38,8 +38,6 @@ func (l *listener) Close() error {
 
 // Listen on a path or port
 func Listen(path string) (Listener, error) {
-	fmt.Println("socket.Listen")
-	fmt.Println(path)
 	url, err := urlx.Parse(path)
 	if err != nil {
 		return nil, err

--- a/package/socket/socket.go
+++ b/package/socket/socket.go
@@ -77,7 +77,7 @@ func Listen(path string) (Listener, error) {
 }
 
 // ListenUp is similar to listen, but will increment the port number until it
-// finds a free one
+// finds a free one or reaches the maximum number of attempts
 func ListenUp(path string, attempts int) (Listener, error) {
 	ln, err := Listen(path)
 	if err != nil {

--- a/package/socket/socket.go
+++ b/package/socket/socket.go
@@ -38,6 +38,8 @@ func (l *listener) Close() error {
 
 // Listen on a path or port
 func Listen(path string) (Listener, error) {
+	fmt.Println("socket.Listen")
+	fmt.Println(path)
 	url, err := urlx.Parse(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR replaces https://github.com/livebud/bud/pull/261. That PR didn't have the push permissions. This PR moves the increment logic into a new method in socket called ListenUp. This makes testing this change quite a bit easier.

Closes: #250 

Unfortunately it's not a complete solution if you have `--hot` enabled (defaults to true with `bud run`):

```sh
bud run
| Listening on http://127.0.0.1:3001
| listen tcp 127.0.0.1:35729: bind: address already in use
```

But it will work if you have another type of server running on port 3000 (e.g. Rails or Next.js)

Keep an eye on https://github.com/livebud/bud/issues/251 for a complete solution.
