### PR TITLE
Makefile: default to install when running 'make'. Closes: #265

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUD_VERSION := $(shell cat version.txt)
 
+default: install
 precommit: test.dev
 
 ##

--- a/contributing/Readme.md
+++ b/contributing/Readme.md
@@ -16,7 +16,7 @@ Run the following commands to download and run Bud locally:
 ```sh
 git clone https://github.com/livebud/bud
 cd bud
-make install # fresh installs take a few minutes because of V8
+make # fresh installs take a few minutes because of V8
 go run main.go
 ```
 


### PR DESCRIPTION
Minor improvement to make it easier to contribute by adding a default target to the `Makefile` so that `make` sets up Bud for contributions.
