### PR TITLE
Add support for custom generators

### DIFF
--- a/example/hn/go.sum
+++ b/example/hn/go.sum
@@ -22,6 +22,7 @@ github.com/gitchander/permutation v0.0.0-20201214100618-1f3e7285f953 h1:+rJDfq6w
 github.com/gitchander/permutation v0.0.0-20201214100618-1f3e7285f953/go.mod h1:lP+DW8LR6Rw3ru9Vo2/y/3iiLaLWmofYql/va+7zJOk=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/keegancsmith/rpc v1.3.0 h1:wGWOpjcNrZaY8GDYZJfvyxmlLljm3YQWF+p918DXtDk=
 github.com/keegancsmith/rpc v1.3.0/go.mod h1:6O2xnOGjPyvIPbvp0MdrOe5r6cu1GZ4JoTzpzDhWeo0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/framework/app/app.gotext
+++ b/framework/app/app.gotext
@@ -83,6 +83,7 @@ func (a *App) Run(ctx context.Context) error {
 		{{- if $.Provider.Variable "github.com/livebud/bud/package/log.Interface" }}log,{{ end }}
 	)
 	if err != nil {
+		budClient.Publish("app:error", []byte(err.Error()))
 		return err
 	}
 	// Inform bud that we're ready

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -1,8 +1,16 @@
 package framework
 
+import "io"
+
 // Flag is used by many of the framework generators
 type Flag struct {
 	Embed  bool
 	Minify bool
 	Hot    bool
+
+	// Comes from *bud.Input
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+	Env    []string
 }

--- a/framework/generator/generator.go
+++ b/framework/generator/generator.go
@@ -1,0 +1,104 @@
+package generator
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/gobuild"
+
+	"github.com/livebud/bud/package/di"
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/parser"
+	"github.com/livebud/bud/package/remotefs"
+
+	"github.com/livebud/bud/internal/gotemplate"
+	"github.com/livebud/bud/package/budfs"
+	"github.com/livebud/bud/package/gomod"
+)
+
+//go:embed generator.gotext
+var template string
+
+var generator = gotemplate.MustParse("framework/generator/generator.gotext", template)
+
+func Generate(state *State) ([]byte, error) {
+	return generator.Generate(state)
+}
+
+func New(flag *framework.Flag, injector *di.Injector, log log.Interface, module *gomod.Module, parser *parser.Parser) *Generator {
+	return &Generator{flag, injector, log, module, parser, nil}
+}
+
+type Generator struct {
+	flag     *framework.Flag
+	injector *di.Injector
+	log      log.Interface
+	module   *gomod.Module
+	parser   *parser.Parser
+
+	// process starts as nil
+	process *remotefs.Process
+}
+
+// GenerateDir connects to the remotefs and mounts the remote directory.
+func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+	g.log.Debug("framework/generator: generating the main.go service containing the generators")
+	state, err := Load(fsys, g.injector, g.module, g.parser)
+	if err != nil {
+		return err
+	}
+	code, err := Generate(state)
+	if err != nil {
+		return err
+	}
+
+	g.log.Debug("framework/generator: write the generator main.go file to bud/tmp/generate/main.go")
+	if err := g.module.MkdirAll("bud/tmp/generate", 0755); err != nil {
+		return err
+	}
+	if err := g.module.WriteFile("bud/tmp/generate/main.go", []byte(code), 0644); err != nil {
+		return err
+	}
+
+	g.log.Debug("framework/generator: build the main.go file to bud/tmp/generate/main")
+	builder := gobuild.New(g.module)
+	builder.Env = append([]string{}, g.flag.Env...)
+	builder.Stderr = g.flag.Stderr
+	builder.Stdout = g.flag.Stdout
+	if err := builder.Build(fsys.Context(), "bud/tmp/generate/main.go", "bud/tmp/generate/main"); err != nil {
+		return fmt.Errorf("framework/generator: unable to build 'bud/tmp/generate/main'. %s", err)
+	}
+
+	if g.process != nil {
+		g.log.Debug("framework/generator: closing existing process")
+		if err := g.process.Close(); err != nil {
+			return err
+		}
+		g.process = nil
+	}
+
+	g.log.Debug("framework/generator: start bud/tmp/generate/main that will serve the remote filesystem")
+	cmd := &remotefs.Command{
+		Dir:    g.module.Directory(),
+		Env:    append([]string{}, g.flag.Env...),
+		Stderr: g.flag.Stderr,
+		Stdout: g.flag.Stdout,
+	}
+	g.process, err = cmd.Start(fsys.Context(), g.module.Directory("bud/tmp/generate/main"))
+	if err != nil {
+		return err
+	}
+
+	// Close the process when the filesystem is closed.
+	fsys.Defer(func() error {
+		if g.process == nil {
+			return nil
+		}
+		g.log.Debug("framework/generator: shutting down the remotefs")
+		return g.process.Close()
+	})
+
+	g.log.Debug("framework/generator: mounting the running remote filesystem to bud/internal/generator/*")
+	return dir.Mount(g.process)
+}

--- a/framework/generator/generator.gotext
+++ b/framework/generator/generator.gotext
@@ -57,13 +57,8 @@ func generate(ctx context.Context) error {
 	{{- range $generator := $.Generators }}
 	bfs.DirGenerator("bud/internal/generator/{{ $generator.Path }}", generators.{{ $generator.Pascal }})
 	{{- end }}
-	{{/* Avoid serving the whole directory from module since that recurse including go.mod and bud/ */}}
-	subfs, err := fs.Sub(bfs, "bud/internal/generator")
-	if err != nil {
-		return err
-	}
 	log.Debug("framework/generator: serving remote 'bud/internal/generator' directory")
-	return remotefs.ServeFrom(ctx, subfs, "")
+	return remotefs.ServeFrom(ctx, bfs, "")
 }
 
 {{/* Provider that creates a function for initializing Generator */}}

--- a/framework/generator/generator.gotext
+++ b/framework/generator/generator.gotext
@@ -55,10 +55,15 @@ func generate(ctx context.Context) error {
 	}
 	bfs := budfs.New(module, log)
 	{{- range $generator := $.Generators }}
-	bfs.DirGenerator("{{ $generator.Path }}", generators.{{ $generator.Pascal }})
+	bfs.DirGenerator("bud/internal/generator/{{ $generator.Path }}", generators.{{ $generator.Pascal }})
 	{{- end }}
-	log.Debug("framework/generator: serving remotefs")
-	return remotefs.ServeFrom(ctx, bfs, "")
+	{{/* Avoid serving the whole directory from module since that recurse including go.mod and bud/ */}}
+	subfs, err := fs.Sub(bfs, "bud/internal/generator")
+	if err != nil {
+		return err
+	}
+	log.Debug("framework/generator: serving remote 'bud/internal/generator' directory")
+	return remotefs.ServeFrom(ctx, subfs, "")
 }
 
 {{/* Provider that creates a function for initializing Generator */}}

--- a/framework/generator/generator.gotext
+++ b/framework/generator/generator.gotext
@@ -1,0 +1,73 @@
+package main
+
+{{- if $.Imports }}
+
+import (
+	{{- range $import := $.Imports }}
+	{{$import.Name}} "{{$import.Path}}"
+	{{- end }}
+)
+{{- end }}
+
+// main entrypoint
+func main() {
+	ctx := context.Background()
+	if err := run(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		console.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	cli := commander.New("generate")
+	cli.Run(generate)
+	return cli.Parse(ctx, os.Args[1:])
+}
+
+func logger() (log.Interface, error) {
+	{{/* TODO: configurable log level */}}
+	handler, err := filter.Load(console.New(os.Stderr), "info")
+	if err != nil {
+		return nil, err
+	}
+	return log.New(handler), nil
+}
+
+func generate(ctx context.Context) error {
+	log, err := logger()
+	if err != nil {
+		return err
+	}
+	module, err := gomod.Find(".")
+	if err != nil {
+		return err
+	}
+	generators, err := {{ $.Provider.Name }}(
+		{{- if $.Provider.Variable "context.Context" }}ctx,{{ end }}
+		{{- if $.Provider.Variable "github.com/livebud/bud/package/gomod.*Module" }}module,{{ end }}
+		{{- if $.Provider.Variable "github.com/livebud/bud/package/log.Interface" }}log,{{ end }}
+	)
+	if err != nil {
+		return err
+	}
+	bfs := budfs.New(module, log)
+	{{- range $generator := $.Generators }}
+	bfs.DirGenerator("{{ $generator.Path }}", generators.{{ $generator.Pascal }})
+	{{- end }}
+	log.Debug("framework/generator: serving remotefs")
+	return remotefs.ServeFrom(ctx, bfs, "")
+}
+
+{{/* Provider that creates a function for initializing Generator */}}
+{{ $.Provider.Function }}
+
+{{/* Generator needs to be synced with *di.Provider */}}
+// Generator is a struct of generators
+type Generator struct {
+	{{- range $generator := $.Generators }}
+	{{ $generator.Pascal }} *{{ $generator.Import.Name }}.Generator
+	{{- end }}
+}

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -235,7 +235,6 @@ func TestUpdateGenerator(t *testing.T) {
 }
 
 func TestRemoveGenerator(t *testing.T) {
-	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -1,0 +1,241 @@
+package generator_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lithammer/dedent"
+	"github.com/livebud/bud/internal/cli/testcli"
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/internal/testdir"
+)
+
+func TestGenerators(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/budfs"
+		)
+		type Generator struct {}
+		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+				file.Data = []byte("/** tailwind **/")
+				return nil
+			})
+			dir.GenerateFile("preflight.css", func(fsys budfs.FS, file *budfs.File) error {
+				file.Data = []byte("/** preflight **/")
+				return nil
+			})
+			return nil
+		}
+	`
+	td.Files["internal/markdoc/markdoc.go"] = `
+		package markdoc
+		import "context"
+		type Compiler struct {}
+		func (c *Compiler) Compile(ctx context.Context, input string) (string, error) {
+			return input + " " + input, nil
+		}
+	`
+	td.Files["view/index.md"] = `# Index`
+	td.Files["view/about/index.md"] = `# About`
+	td.Files["generator/markdoc/markdoc.go"] = `
+		package markdoc
+		import (
+			"app.com/internal/markdoc"
+			"github.com/livebud/bud/package/budfs"
+			"io/fs"
+			"strings"
+		)
+		type Generator struct {
+			Markdoc *markdoc.Compiler
+		}
+		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+			dir.GenerateFile("view/index.md", g.compile)
+			dir.GenerateFile("view/about/index.md", g.compile)
+			return nil
+		}
+		func (g *Generator) compile(fsys budfs.FS, file *budfs.File) error {
+			data, err := fs.ReadFile(fsys, strings.TrimPrefix(file.Target(), "markdoc/"))
+			if err != nil {
+				return err
+			}
+			result, err := g.Markdoc.Compile(fsys.Context(), string(data))
+			if err != nil {
+				return err
+			}
+			file.Data = []byte(result)
+			return nil
+		}
+	`
+	td.Files["generator/web/viewer/viewer.go"] = `
+		package viewer
+		import (
+			"github.com/livebud/bud/package/budfs"
+		)
+		type Generator struct {
+		}
+		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+			dir.GenerateFile("viewer.go", func(fsys budfs.FS, file *budfs.File) error {
+				file.Data = []byte("package viewer")
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	_, err := cli.Run(ctx, "build", "--embed=false")
+	is.NoErr(err)
+	is.NoErr(td.Exists("bud/tmp/generate/main.go"))
+	is.NoErr(td.Exists("bud/internal/generator/tailwind/tailwind.css"))
+	is.NoErr(td.Exists("bud/internal/generator/tailwind/preflight.css"))
+	is.NoErr(td.Exists("bud/internal/generator/markdoc/view/index.md"))
+	is.NoErr(td.Exists("bud/internal/generator/markdoc/view/about/index.md"))
+	is.NoErr(td.Exists("bud/internal/generator/web/viewer/viewer.go"))
+	data, err := os.ReadFile(td.Path("bud/internal/generator/tailwind/tailwind.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** tailwind **/")
+	data, err = os.ReadFile(td.Path("bud/internal/generator/tailwind/preflight.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** preflight **/")
+	data, err = os.ReadFile(td.Path("bud/internal/generator/markdoc/view/index.md"))
+	is.NoErr(err)
+	is.Equal(string(data), "# Index # Index")
+	data, err = os.ReadFile(td.Path("bud/internal/generator/markdoc/view/about/index.md"))
+	is.NoErr(err)
+	is.Equal(string(data), "# About # About")
+	data, err = os.ReadFile(td.Path("bud/internal/generator/web/viewer/viewer.go"))
+	is.NoErr(err)
+	is.Equal(string(data), "package viewer")
+}
+
+func TestMissingGenerator(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/web/transform/transform.go"] = `
+		package transform
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	_, err := cli.Run(ctx, "build", "--embed=false")
+	is.True(err != nil)
+	is.In(err.Error(), `generator: no Generator struct in "app.com/generator/web/transform"`)
+}
+
+func TestMissingGenerateDirMethod(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/web/transform/transform.go"] = `
+		package transform
+		type Generator struct {}
+		func (g *Generator) Generate() error { return nil }
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	_, err := cli.Run(ctx, "build", "--embed=false")
+	is.True(err != nil)
+	is.In(err.Error(), `generator: no (*Generator).GenerateDir(...) method in "app.com/generator/web/transform"`)
+}
+
+func TestSyntaxError(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/budfs"
+		)
+		type Generator struct {}
+		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+			return "not an error"
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	res, err := cli.Run(ctx, "build", "--embed=false")
+	is.True(err != nil)
+	is.In(err.Error(), `exit status 2`)
+	is.In(res.Stderr(), `string does not implement error (missing Error method)`)
+}
+
+func TestUpdateGenerator(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["controller/controller.go"] = `
+		package controller
+		type Controller struct {}
+		func (c *Controller) Index() (string, error) { return "/", nil }
+	`
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/budfs"
+		)
+		type Generator struct {}
+		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+				file.Data = []byte("/** tailwind **/")
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	app, err := cli.Start(ctx, "run")
+	is.NoErr(err)
+	defer app.Close()
+	// Check for tailwind
+	data, err := os.ReadFile(td.Path("bud/internal/generator/tailwind/tailwind.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** tailwind **/")
+	// Update generator
+	generatorFile := filepath.Join(dir, "generator", "tailwind", "tailwind.go")
+	is.NoErr(os.WriteFile(generatorFile, []byte(dedent.Dedent(`
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/budfs"
+		)
+		type Generator struct {
+		}
+		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
+			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+				file.Data = []byte("/** tailwind2 **/")
+				return nil
+			})
+			dir.GenerateFile("preflight.css", func(fsys budfs.FS, file *budfs.File) error {
+				file.Data = []byte("/** preflight **/")
+				return nil
+			})
+			return nil
+		}
+	`)), 0644))
+	// Wait for the app to be ready again
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	is.NoErr(app.Ready(ctx))
+	// Check for preflight
+	data, err = os.ReadFile(td.Path("bud/internal/generator/tailwind/preflight.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** preflight **/")
+	// Check that tailwind has been updated
+	data, err = os.ReadFile(td.Path("bud/internal/generator/tailwind/tailwind.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** tailwind2 **/")
+}

--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -1,0 +1,137 @@
+package generator
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/livebud/bud/internal/bail"
+	"github.com/livebud/bud/internal/imports"
+	"github.com/livebud/bud/internal/scan"
+	"github.com/livebud/bud/internal/valid"
+	"github.com/livebud/bud/package/budfs"
+	"github.com/livebud/bud/package/di"
+	"github.com/livebud/bud/package/gomod"
+	"github.com/livebud/bud/package/parser"
+	"github.com/matthewmueller/gotext"
+)
+
+func Load(fsys budfs.FS, injector *di.Injector, module *gomod.Module, parser *parser.Parser) (*State, error) {
+	return (&loader{
+		injector: injector,
+		module:   module,
+		parser:   parser,
+		imports:  imports.New(),
+	}).Load(fsys)
+}
+
+type loader struct {
+	injector *di.Injector
+	module   *gomod.Module
+	parser   *parser.Parser
+	imports  *imports.Set
+	bail.Struct
+}
+
+func (l *loader) Load(bfs budfs.FS) (state *State, err error) {
+	defer l.Recover2(&err, "generator")
+	state = new(State)
+	// TODO: replace with a watch function, this is currently wasteful if we're
+	// not going to use the results
+	if files, err := fs.Glob(bfs, "generator/**.go"); err != nil {
+		return nil, err
+	} else if len(files) == 0 {
+		return nil, fs.ErrNotExist
+	}
+	state.Generators = l.loadGenerators(bfs)
+	if len(state.Generators) == 0 {
+		return nil, fs.ErrNotExist
+	}
+	state.Provider = l.loadProvider(state.Generators)
+	l.imports.AddStd("context", "os", "errors")
+	l.imports.AddNamed("gomod", "github.com/livebud/bud/package/gomod")
+	l.imports.AddNamed("log", "github.com/livebud/bud/package/log")
+	l.imports.AddNamed("filter", "github.com/livebud/bud/package/log/filter")
+	l.imports.AddNamed("console", "github.com/livebud/bud/package/log/console")
+	l.imports.AddNamed("commander", "github.com/livebud/bud/package/commander")
+	l.imports.AddNamed("remotefs", "github.com/livebud/bud/package/remotefs")
+	l.imports.AddNamed("budfs", "github.com/livebud/bud/package/budfs")
+	state.Imports = l.imports.List()
+	return state, nil
+}
+
+func (l *loader) loadGenerators(bfs budfs.FS) (generators []*UserGenerator) {
+	generatorDirs, err := scan.List(bfs, "generator", func(de fs.DirEntry) bool {
+		if de.IsDir() {
+			return valid.Dir(de.Name())
+		} else {
+			return valid.GoFile(de.Name())
+		}
+	})
+	if err != nil {
+		l.Bail(err)
+	}
+	for _, generatorDir := range generatorDirs {
+		importPath := l.module.Import(generatorDir)
+		pkg, err := l.parser.Parse(generatorDir)
+		if err != nil {
+			l.Bail(err)
+		}
+		// Ensure the package has a generator
+		// TODO: ensure the package has a GenerateDir function that
+		// matches the accepted signature
+		if s := pkg.Struct("Generator"); s == nil {
+			l.Bail(fmt.Errorf("no Generator struct in %q", importPath))
+		} else if s.Method("GenerateDir") == nil {
+			l.Bail(fmt.Errorf("no (*Generator).GenerateDir(...) method in %q", importPath))
+		}
+		imp := &imports.Import{
+			Name: l.imports.Add(importPath),
+			Path: importPath,
+		}
+		rootlessGenerator := strings.TrimPrefix(generatorDir, "generator/")
+		generators = append(generators, &UserGenerator{
+			Import: imp,
+			Path:   rootlessGenerator,
+			Pascal: gotext.Pascal(rootlessGenerator),
+		})
+	}
+	return generators
+}
+
+func (l *loader) loadProvider(generators []*UserGenerator) *di.Provider {
+	structFields := make([]*di.StructField, len(generators))
+	for i, generator := range generators {
+		structFields[i] = &di.StructField{
+			Name:   generator.Pascal,
+			Import: generator.Import.Path,
+			Type:   "*Generator",
+		}
+	}
+	provider, err := l.injector.Wire(&di.Function{
+		Name:    "loadGenerators",
+		Target:  l.module.Import("bud/internal/generator"),
+		Imports: l.imports,
+		Params: []*di.Param{
+			{Import: "github.com/livebud/bud/package/log", Type: "Interface"},
+			{Import: "github.com/livebud/bud/package/gomod", Type: "*Module"},
+			{Import: "context", Type: "Context"},
+		},
+		Results: []di.Dependency{
+			&di.Struct{
+				Import: l.module.Import("bud/internal/generator"),
+				Type:   "*Generator",
+				Fields: structFields,
+			},
+			&di.Error{},
+		},
+	})
+	if err != nil {
+		l.Bail(err)
+	}
+	// Add generated imports
+	for _, imp := range provider.Imports {
+		l.imports.AddNamed(imp.Name, imp.Path)
+	}
+	return provider
+}

--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -48,7 +48,7 @@ func (l *loader) Load(bfs budfs.FS) (state *State, err error) {
 		return nil, fs.ErrNotExist
 	}
 	state.Provider = l.loadProvider(state.Generators)
-	l.imports.AddStd("context", "os", "errors")
+	l.imports.AddStd("context", "os", "errors", "io/fs")
 	l.imports.AddNamed("gomod", "github.com/livebud/bud/package/gomod")
 	l.imports.AddNamed("log", "github.com/livebud/bud/package/log")
 	l.imports.AddNamed("filter", "github.com/livebud/bud/package/log/filter")

--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -48,7 +48,7 @@ func (l *loader) Load(bfs budfs.FS) (state *State, err error) {
 		return nil, fs.ErrNotExist
 	}
 	state.Provider = l.loadProvider(state.Generators)
-	l.imports.AddStd("context", "os", "errors", "io/fs")
+	l.imports.AddStd("context", "os", "errors")
 	l.imports.AddNamed("gomod", "github.com/livebud/bud/package/gomod")
 	l.imports.AddNamed("log", "github.com/livebud/bud/package/log")
 	l.imports.AddNamed("filter", "github.com/livebud/bud/package/log/filter")

--- a/framework/generator/state.go
+++ b/framework/generator/state.go
@@ -1,0 +1,18 @@
+package generator
+
+import (
+	"github.com/livebud/bud/internal/imports"
+	"github.com/livebud/bud/package/di"
+)
+
+type State struct {
+	Imports    []*imports.Import
+	Generators []*UserGenerator
+	Provider   *di.Provider
+}
+
+type UserGenerator struct {
+	Import *imports.Import
+	Path   string
+	Pascal string
+}

--- a/internal/cli/bud/bud.go
+++ b/internal/cli/bud/bud.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/framework/app"
 	"github.com/livebud/bud/framework/controller"
+	"github.com/livebud/bud/framework/generator"
 	"github.com/livebud/bud/framework/public"
 	"github.com/livebud/bud/framework/transform/transformrt"
 	"github.com/livebud/bud/framework/view"
@@ -118,7 +119,7 @@ func Log(stderr io.Writer, logFilter string) (log.Interface, error) {
 	return log.New(handler), nil
 }
 
-func FileSystem(ctx context.Context, log log.Interface, module *gomod.Module, flag *framework.Flag, in *Input) (*budfs.FileSystem, error) {
+func FileSystem(ctx context.Context, log log.Interface, module *gomod.Module, flag *framework.Flag) (*budfs.FileSystem, error) {
 	bfs := budfs.New(module, log)
 	parser := parser.New(bfs, module)
 	injector := di.New(bfs, log, module, parser)
@@ -142,6 +143,7 @@ func FileSystem(ctx context.Context, log log.Interface, module *gomod.Module, fl
 	bfs.FileGenerator("bud/view/_ssr.js", ssr.New(module, transforms.SSR))
 	bfs.FileServer("bud/view", dom.New(module, transforms.DOM))
 	bfs.FileServer("bud/node_modules", dom.NodeModules(module))
+	bfs.DirGenerator("bud/internal/generator", generator.New(flag, injector, log, module, parser))
 	return bfs, nil
 }
 

--- a/internal/cli/build/build.go
+++ b/internal/cli/build/build.go
@@ -12,9 +12,14 @@ import (
 // New command for bud build
 func New(bud *bud.Command, in *bud.Input) *Command {
 	return &Command{
-		bud:  bud,
-		in:   in,
-		Flag: new(framework.Flag),
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
 	}
 }
 
@@ -41,11 +46,12 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag, c.in)
+	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
 	if err != nil {
 		return err
 	}
 	defer bfs.Close()
+	// Generate the application
 	if err := bfs.Sync(module, "bud/internal"); err != nil {
 		return err
 	}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -31,9 +31,14 @@ import (
 // New command for bud run.
 func New(bud *bud.Command, in *bud.Input) *Command {
 	return &Command{
-		bud:  bud,
-		in:   in,
-		Flag: new(framework.Flag),
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
 	}
 }
 
@@ -92,7 +97,7 @@ func (c *Command) Run(ctx context.Context) (err error) {
 		log.Debug("run: bud server is listening", "url", "http://"+budln.Addr().String())
 	}
 	// Load the generator filesystem
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag, c.in)
+	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
 	if err != nil {
 		return err
 	}
@@ -115,7 +120,8 @@ func (c *Command) Run(ctx context.Context) (err error) {
 		Stdout: c.in.Stdout,
 		Stderr: c.in.Stderr,
 		Dir:    module.Directory(),
-		Env: append(c.in.Env,
+		Env: append(
+			append([]string{}, c.in.Env...),
 			"BUD_LISTEN="+budln.Addr().String(),
 		),
 	}

--- a/internal/cli/toolbs/toolbs.go
+++ b/internal/cli/toolbs/toolbs.go
@@ -14,9 +14,14 @@ import (
 
 func New(bud *bud.Command, in *bud.Input) *Command {
 	return &Command{
-		bud:  bud,
-		in:   in,
-		Flag: new(framework.Flag),
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
 	}
 }
 
@@ -40,7 +45,7 @@ func (c *Command) Run(ctx context.Context) error {
 		return err
 	}
 	// Load the file server
-	servefs, err := bud.FileSystem(ctx, log, module, c.Flag, c.in)
+	servefs, err := bud.FileSystem(ctx, log, module, c.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/toolfscat/toolfscat.go
+++ b/internal/cli/toolfscat/toolfscat.go
@@ -13,9 +13,14 @@ import (
 
 func New(bud *bud.Command, in *bud.Input) *Command {
 	return &Command{
-		bud:  bud,
-		in:   in,
-		Flag: new(framework.Flag),
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
 	}
 }
 
@@ -35,7 +40,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag, c.in)
+	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/toolfsls/toolfsls.go
+++ b/internal/cli/toolfsls/toolfsls.go
@@ -14,9 +14,14 @@ import (
 
 func New(bud *bud.Command, in *bud.Input) *Command {
 	return &Command{
-		bud:  bud,
-		in:   in,
-		Flag: new(framework.Flag),
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
 	}
 }
 
@@ -37,7 +42,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag, c.in)
+	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/toolfstxtar/toolfstxtar.go
+++ b/internal/cli/toolfstxtar/toolfstxtar.go
@@ -15,9 +15,14 @@ import (
 
 func New(bud *bud.Command, in *bud.Input) *Command {
 	return &Command{
-		bud:  bud,
-		in:   in,
-		Flag: new(framework.Flag),
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
 	}
 }
 
@@ -38,7 +43,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag, c.in)
+	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
 	if err != nil {
 		return err
 	}

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -23,7 +23,6 @@ package prompter
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -67,12 +66,12 @@ type Prompter struct {
 
 // Clear line with cursor on.
 func clearLine() {
-	fmt.Fprint(os.Stderr, "\033[0K")
+	// fmt.Fprint(os.Stderr, "\033[0K")
 }
 
 // Move cursor up 1 line.
 func moveCursorUp() {
-	fmt.Fprint(os.Stderr, "\033[1A")
+	// fmt.Fprint(os.Stderr, "\033[1A")
 }
 
 func (p *Prompter) startTimer() {

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -23,6 +23,7 @@ package prompter
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -66,12 +67,12 @@ type Prompter struct {
 
 // Clear line with cursor on.
 func clearLine() {
-	// fmt.Fprint(os.Stderr, "\033[0K")
+	fmt.Fprint(os.Stderr, "\033[0K")
 }
 
 // Move cursor up 1 line.
 func moveCursorUp() {
-	// fmt.Fprint(os.Stderr, "\033[1A")
+	fmt.Fprint(os.Stderr, "\033[1A")
 }
 
 func (p *Prompter) startTimer() {

--- a/package/budfs/budfs.go
+++ b/package/budfs/budfs.go
@@ -49,7 +49,8 @@ type FileSystem struct {
 
 type File struct {
 	Data   []byte
-	node   *treefs.Node
+	path   string
+	mode   fs.FileMode
 	target string
 }
 
@@ -58,15 +59,15 @@ func (f *File) Target() string {
 }
 
 func (f *File) Relative() string {
-	return relativePath(f.node.Path(), f.target)
+	return relativePath(f.path, f.target)
 }
 
 func (f *File) Path() string {
-	return f.node.Path()
+	return f.path
 }
 
 func (f *File) Mode() fs.FileMode {
-	return f.node.Mode()
+	return f.mode
 }
 
 type FS interface {
@@ -101,7 +102,7 @@ func (d *Dir) Mode() fs.FileMode {
 }
 
 func (d *Dir) GenerateFile(path string, fn func(fsys FS, file *File) error) {
-	fileg := &fileGenerator{d.fsys, fn, nil}
+	fileg := &fileGenerator{d.fsys, fn, nil, path}
 	fileg.node = d.node.FileGenerator(path, fileg)
 }
 
@@ -193,6 +194,7 @@ type fileGenerator struct {
 	fsys *FileSystem
 	fn   func(fsys FS, file *File) error
 	node *treefs.Node
+	path string
 }
 
 func (g *fileGenerator) Generate(target string) (fs.File, error) {
@@ -200,7 +202,7 @@ func (g *fileGenerator) Generate(target string) (fs.File, error) {
 		return virtual.New(entry), nil
 	}
 	fctx := &fileSystem{context.TODO(), g.fsys, g.fsys.lmap.Scope(target)}
-	file := &File{nil, g.node, target}
+	file := &File{nil, g.path, g.node.Mode(), target}
 	g.fsys.log.Debug("budfs: running file generator function", "target", target)
 	if err := g.fn(fctx, file); err != nil {
 		return nil, err
@@ -215,7 +217,7 @@ func (g *fileGenerator) Generate(target string) (fs.File, error) {
 }
 
 func (f *FileSystem) GenerateFile(path string, fn func(fsys FS, file *File) error) {
-	fileg := &fileGenerator{f, fn, nil}
+	fileg := &fileGenerator{f, fn, nil, path}
 	fileg.node = f.node.FileGenerator(path, fileg)
 }
 
@@ -233,6 +235,8 @@ func (g *dirGenerator) Generate(target string) (fs.File, error) {
 	if _, ok := g.fsys.cache.Get(g.node.Path()); ok {
 		return g.node.Open(target)
 	}
+	// Clear the subdirectories
+	g.node.Clear()
 	fctx := &fileSystem{context.TODO(), g.fsys, g.fsys.lmap.Scope(target)}
 	dir := &Dir{g.fsys, g.node, target}
 	g.fsys.log.Debug("budfs: running dir generator function", "path", g.node.Path(), "target", target)
@@ -260,6 +264,7 @@ type fileServer struct {
 	fsys *FileSystem
 	fn   func(fsys FS, file *File) error
 	node *treefs.Node
+	path string
 }
 
 func (g *fileServer) Generate(target string) (fs.File, error) {
@@ -277,7 +282,7 @@ func (g *fileServer) Generate(target string) (fs.File, error) {
 	fctx := &fileSystem{context.TODO(), g.fsys, g.fsys.lmap.Scope(target)}
 	// File differs slightly than others because g.node.Path() is the directory
 	// path, but we want the target path for serving files.
-	file := &File{nil, g.node, target}
+	file := &File{nil, g.path, g.node.Mode(), target}
 	g.fsys.log.Debug("budfs: running file server function", "path", g.node.Path(), "target", target)
 	if err := g.fn(fctx, file); err != nil {
 		return nil, err
@@ -292,7 +297,7 @@ func (g *fileServer) Generate(target string) (fs.File, error) {
 }
 
 func (f *FileSystem) ServeFile(dir string, fn func(fsys FS, file *File) error) {
-	fileg := &fileServer{f, fn, nil}
+	fileg := &fileServer{f, fn, nil, dir}
 	fileg.node = f.node.DirGenerator(dir, fileg)
 }
 

--- a/package/budfs/budfs_test.go
+++ b/package/budfs/budfs_test.go
@@ -705,43 +705,6 @@ func TestDirUnevenMerge(t *testing.T) {
 	is.Equal(string(code), "package controller")
 }
 
-func TestDirMerge(t *testing.T) {
-	is := is.New(t)
-	fsys := virtual.Map{}
-	log := testlog.New()
-	bfs := budfs.New(fsys, log)
-	bfs.GenerateDir("bud/view", func(fsys budfs.FS, dir *budfs.Dir) error {
-		dir.GenerateFile("index.svelte", func(fsys budfs.FS, file *budfs.File) error {
-			file.Data = []byte(`<h1>index</h1>`)
-			return nil
-		})
-		dir.GenerateDir("somedir", func(fsys budfs.FS, dir *budfs.Dir) error {
-			return nil
-		})
-		return nil
-	})
-	bfs.GenerateFile("bud/view/view.go", func(fsys budfs.FS, file *budfs.File) error {
-		file.Data = []byte(`package view`)
-		return nil
-	})
-	bfs.GenerateFile("bud/view/plugin.go", func(fsys budfs.FS, file *budfs.File) error {
-		file.Data = []byte(`package plugin`)
-		return nil
-	})
-	// bud/view
-	des, err := fs.ReadDir(bfs, "bud/view")
-	is.NoErr(err)
-	is.Equal(len(des), 4)
-	is.Equal(des[0].Name(), "index.svelte")
-	is.Equal(des[0].IsDir(), false)
-	is.Equal(des[1].Name(), "plugin.go")
-	is.Equal(des[1].IsDir(), false)
-	is.Equal(des[2].Name(), "somedir")
-	is.Equal(des[2].IsDir(), true)
-	is.Equal(des[3].Name(), "view.go")
-	is.Equal(des[3].IsDir(), false)
-}
-
 // Add the view
 func TestAddGenerator(t *testing.T) {
 	is := is.New(t)
@@ -814,15 +777,6 @@ func TestDirGenerator(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(string(code), "aa")
 }
-
-// func TestFileServer(t *testing.T) {
-// 	is := is.New(t)
-// 	bfs := bfsfs.New()
-// 	bfs.FileServer("bud/view", &commandGenerator{Input: "a"})
-// 	code, err := fs.ReadFile(bfs, "bud/view/index.svelte")
-// 	is.NoErr(err)
-// 	is.Equal(string(code), "a/bud/view/index.svelte")
-// }
 
 func TestDotReadDirEmpty(t *testing.T) {
 	is := is.New(t)
@@ -1462,239 +1416,40 @@ func TestCacheMount(t *testing.T) {
 	is.Equal(count["bud/generator/b.txt"], 1, "wrong bud/generator/b.txt mount reads")
 }
 
-// func TestRemoteFS(t *testing.T) {
-// 	is := is.New(t)
-// 	parent := func(t testing.TB, cmd *exec.Cmd) {
-// 		ctx := context.Background()
-// 		is := is.New(t)
-// 		log := testlog.New()
-// 		dir := t.TempDir()
-// 		td := testdir.New(dir)
-// 		err := td.Write(ctx)
-// 		is.NoErr(err)
-// 		module, err := gomod.Find(dir)
-// 		is.NoErr(err)
-// 		bfs := budfs.New(module, log)
-// 		count := 1
-// 		bfs.GenerateDir("bud/generator", func(fsys budfs.FS, dir *budfs.Dir) error {
-// 			dir.GenerateFile(dir.Relative(), func(fsys budfs.FS, file *budfs.File) error {
-// 				command := remotefs.Command{
-// 					Env:    cmd.Env,
-// 					Stderr: os.Stderr,
-// 					Stdout: os.Stdout,
-// 				}
-// 				remotefs, err := command.Start(ctx, cmd.Path, cmd.Args[1:]...)
-// 				if err != nil {
-// 					return err
-// 				}
-// 				defer remotefs.Close()
-// 				data, err := fs.ReadFile(remotefs, dir.Relative())
-// 				if err != nil {
-// 					return err
-// 				}
-// 				file.Data = []byte(strings.Repeat(string(data), count))
-// 				count++
-// 				return nil
-// 			})
-// 			return nil
-// 		})
-// 		code, err := fs.ReadFile(bfs, "bud/generator/a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		// Cached
-// 		code, err = fs.ReadFile(bfs, "bud/generator/a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		// Read new path (uncached)
-// 		code, err = fs.ReadFile(bfs, "bud/generator/b.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "bb")
-// 		// Update the file
-// 		bfs.Update("bud/generator/a.txt")
-// 		// Read again
-// 		code, err = fs.ReadFile(bfs, "bud/generator/a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "aaa")
-// 	}
-// 	child := func(t testing.TB) {
-// 		ctx := context.Background()
-// 		fsys := virtual.Memory{
-// 			"a.txt": &fstest.MapFile{Data: []byte("a")},
-// 			"b.txt": &fstest.MapFile{Data: []byte("b")},
-// 		}
-// 		err := remotefs.ServeFrom(ctx, fsys, "")
-// 		is.NoErr(err)
-// 	}
-// 	testsub.Run(t, parent, child)
-// }
-
-// func TestMountRemoteFS(t *testing.T) {
-// 	ctx := context.Background()
-// 	is := is.New(t)
-// 	log := testlog.New()
-// 	dir := t.TempDir()
-// 	td := testdir.New(dir)
-// 	err := td.Write(ctx)
-// 	is.NoErr(err)
-// 	module, err := gomod.Find(dir)
-// 	is.NoErr(err)
-// 	parent := func(t testing.TB, cmd *exec.Cmd) {
-// 		bfs := budfs.New(module, log)
-// 		command := remotefs.Command{
-// 			Env:    cmd.Env,
-// 			Stderr: os.Stderr,
-// 			Stdout: os.Stdout,
-// 		}
-// 		remotefs, err := command.Start(ctx, cmd.Path, cmd.Args[1:]...)
-// 		is.NoErr(err)
-// 		defer remotefs.Close()
-// 		bfs.Mount("bud/generator", remotefs)
-// 		code, err := fs.ReadFile(bfs, "bud/generator/a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		// Cached
-// 		code, err = fs.ReadFile(bfs, "bud/generator/a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		// Read new path (uncached)
-// 		code, err = fs.ReadFile(bfs, "bud/generator/b.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "bb")
-// 		// Update the file
-// 		bfs.Update("bud/generator/a.txt")
-// 		// Read again
-// 		code, err = fs.ReadFile(bfs, "bud/generator/a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 	}
-// 	child := func(t testing.TB) {
-// 		count := 1
-// 		bfs := budfs.New(module, log)
-// 		bfs.GenerateFile("a.txt", func(fsys budfs.FS, file *budfs.File) error {
-// 			file.Data = []byte(strings.Repeat(string("a"), count))
-// 			count++
-// 			return nil
-// 		})
-// 		bfs.GenerateFile("b.txt", func(fsys budfs.FS, file *budfs.File) error {
-// 			file.Data = []byte(strings.Repeat(string("b"), count))
-// 			count++
-// 			return nil
-// 		})
-// 		err := remotefs.ServeFrom(ctx, bfs, "")
-// 		is.NoErr(err)
-// 	}
-// 	testsub.Run(t, parent, child)
-// }
-
-// type remoteService struct {
-// 	cmd     *exec.Cmd
-// 	process *remotefs.Process
-// }
-
-// func (s *remoteService) GenerateFile(fsys budfs.FS, file *budfs.File) (err error) {
-// 	// This remote service depends on the generators
-// 	_, err = fs.Glob(fsys, "generator/*/*.go")
-// 	if err != nil {
-// 		return err
-// 	}
-// 	if s.process != nil {
-// 		if err := s.process.Close(); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	command := remotefs.Command{
-// 		Env:    s.cmd.Env,
-// 		Stderr: os.Stderr,
-// 		Stdout: os.Stdout,
-// 	}
-// 	s.process, err = command.Start(fsys.Context(), s.cmd.Path, s.cmd.Args[1:]...)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	fsys.Defer(func() error {
-// 		return s.process.Close()
-// 	})
-// 	file.Data = []byte(s.process.URL())
-// 	return nil
-// }
-
-// func TestRemoteService(t *testing.T) {
-// 	ctx := context.Background()
-// 	is := is.New(t)
-// 	log := testlog.New()
-// 	dir := t.TempDir()
-// 	td := testdir.New(dir)
-// 	td.Files["generator/tailwind/tailwind.go"] = "package tailwind"
-// 	err := td.Write(ctx)
-// 	is.NoErr(err)
-// 	module, err := gomod.Find(dir)
-// 	is.NoErr(err)
-// 	parent := func(t testing.TB, cmd *exec.Cmd) {
-// 		bfs := budfs.New(module, log)
-// 		defer bfs.Close()
-// 		bfs.FileGenerator("bud/service/generator.url", &remoteService{cmd: cmd})
-// 		// Return a URL to connect to
-// 		url, err := fs.ReadFile(bfs, "bud/service/generator.url")
-// 		is.NoErr(err)
-// 		// Dial that URL
-// 		client, err := remotefs.Dial(ctx, string(url))
-// 		is.NoErr(err)
-// 		defer client.Close()
-// 		// Read the remote file
-// 		code, err := fs.ReadFile(client, "a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		// Cached
-// 		code, err = fs.ReadFile(client, "a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		// Uncached because it's a new file
-// 		code, err = fs.ReadFile(client, "b.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "bb")
-// 		// Still cached
-// 		url, err = fs.ReadFile(bfs, "bud/service/generator.url")
-// 		is.NoErr(err)
-// 		code, err = fs.ReadFile(client, "a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		code, err = fs.ReadFile(client, "b.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "bb")
-// 		// Update a dependency
-// 		bfs.Update("generator/tailwind/tailwind.go")
-// 		// Should lead to the generator service being uncached again
-// 		url2, err := fs.ReadFile(bfs, "bud/service/generator.url")
-// 		is.NoErr(err)
-// 		is.True(!bytes.Equal(url, url2))
-// 		// Dial the new URL
-// 		client2, err := remotefs.Dial(ctx, string(url2))
-// 		is.NoErr(err)
-// 		defer client2.Close()
-// 		// Still cached, even though the remote has been restarted
-// 		code, err = fs.ReadFile(client2, "a.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "a")
-// 		code, err = fs.ReadFile(client2, "b.txt")
-// 		is.NoErr(err)
-// 		is.Equal(string(code), "bb")
-// 	}
-// 	child := func(t testing.TB) {
-// 		count := 1
-// 		bfs := budfs.New(module, log)
-// 		defer bfs.Close()
-// 		bfs.GenerateFile("a.txt", func(fsys budfs.FS, file *budfs.File) error {
-// 			file.Data = []byte(strings.Repeat(string("a"), count))
-// 			count++
-// 			return nil
-// 		})
-// 		bfs.GenerateFile("b.txt", func(fsys budfs.FS, file *budfs.File) error {
-// 			file.Data = []byte(strings.Repeat(string("b"), count))
-// 			count++
-// 			return nil
-// 		})
-// 		err := remotefs.ServeFrom(ctx, bfs, "")
-// 		is.NoErr(err)
-// 	}
-// 	testsub.Run(t, parent, child)
-// }
+func TestChangingMount(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	fsys := virtual.Map{}
+	bfs := budfs.New(fsys, log)
+	m1 := virtual.Tree{
+		"a.txt": &virtual.File{Data: []byte("a")},
+	}
+	m2 := virtual.Tree{
+		"b.txt": &virtual.File{Data: []byte("b")},
+	}
+	bfs.GenerateDir("bud", func(fsys budfs.FS, dir *budfs.Dir) error {
+		if dir.Target() == "bud/a.txt" {
+			return dir.Mount(m1)
+		}
+		if dir.Target() == "bud/b.txt" {
+			return dir.Mount(m2)
+		}
+		return nil
+	})
+	// Initial tests
+	code, err := fs.ReadFile(bfs, "bud/a.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "a", "wrong a.txt code")
+	code, err = fs.ReadFile(bfs, "bud/b.txt")
+	is.True(errors.Is(err, fs.ErrNotExist))
+	is.Equal(code, nil)
+	// Mark the directory as changed
+	bfs.Change("bud")
+	// It should reverse
+	code, err = fs.ReadFile(bfs, "bud/b.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "b", "wrong b.txt code")
+	code, err = fs.ReadFile(bfs, "bud/a.txt")
+	is.True(errors.Is(err, fs.ErrNotExist), "bud/a.txt should not exist")
+	is.Equal(code, nil)
+}

--- a/package/budfs/treefs/treefs.go
+++ b/package/budfs/treefs/treefs.go
@@ -164,6 +164,22 @@ func (n *Node) mkdirAll(segments []string) *Node {
 	return parent
 }
 
+func (n *Node) Remove(path string) {
+	child, ok := n.childMap[path]
+	if !ok {
+		return
+	}
+	child.parent = nil
+	delete(n.childMap, path)
+}
+
+func (n *Node) Clear() {
+	for _, child := range n.childMap {
+		child.parent = nil
+	}
+	n.childMap = map[string]*Node{}
+}
+
 func formatNode(node *Node) string {
 	if node.kind == kindGenerator {
 		return fmt.Sprintf("%s generator=%v mode=%s", node.name, node.generator, node.mode)

--- a/package/budfs/treefs/treefs_test.go
+++ b/package/budfs/treefs/treefs_test.go
@@ -229,3 +229,51 @@ func TestGenerate(t *testing.T) {
 	err := fstest.TestFS(n, "bud/node_modules/runtime")
 	is.NoErr(err)
 }
+
+func TestRemove(t *testing.T) {
+	is := is.New(t)
+	n := treefs.New(".")
+	n.FileGenerator("a", ag)
+	bn := n.DirGenerator("b", bg)
+	cn := bn.DirGenerator("c", cg)
+	cn.FileGenerator("e", eg)
+	cn.FileGenerator("f", fg)
+	expect := `. mode=d---------
+├── a generator=a mode=----------
+└── b generator=b mode=d---------
+    └── c generator=c mode=d---------
+        ├── e generator=e mode=----------
+        └── f generator=f mode=----------
+`
+	is.Equal(n.Print(), expect)
+	n.Remove("b")
+	expect = `. mode=d---------
+└── a generator=a mode=----------
+`
+	is.Equal(n.Print(), expect)
+}
+
+func TestClear(t *testing.T) {
+	is := is.New(t)
+	n := treefs.New(".")
+	n.FileGenerator("a", ag)
+	bn := n.DirGenerator("b", bg)
+	cn := bn.DirGenerator("c", cg)
+	cn.FileGenerator("e", eg)
+	cn.FileGenerator("f", fg)
+	expect := `. mode=d---------
+├── a generator=a mode=----------
+└── b generator=b mode=d---------
+    └── c generator=c mode=d---------
+        ├── e generator=e mode=----------
+        └── f generator=f mode=----------
+`
+	is.Equal(n.Print(), expect)
+	cn.Clear()
+	expect = `. mode=d---------
+├── a generator=a mode=----------
+└── b generator=b mode=d---------
+    └── c generator=c mode=d---------
+`
+	is.Equal(n.Print(), expect)
+}

--- a/package/remotefs/command.go
+++ b/package/remotefs/command.go
@@ -73,5 +73,8 @@ func (p *Process) ReadDir(name string) (des []fs.DirEntry, err error) {
 }
 
 func (p *Process) Close() error {
-	return p.closer.Close()
+	if err := p.closer.Close(); err != nil {
+		return err
+	}
+	return p.process.Wait()
 }

--- a/package/virtual/exclude.go
+++ b/package/virtual/exclude.go
@@ -1,0 +1,39 @@
+package virtual
+
+import (
+	"io/fs"
+	"path"
+)
+
+func Exclude(fsys fs.FS, fn func(path string) bool) fs.FS {
+	return &exclude{fsys, fn}
+}
+
+type exclude struct {
+	fsys fs.FS
+	fn   func(path string) bool
+}
+
+func (e *exclude) Open(path string) (fs.File, error) {
+	if e.fn(path) {
+		return nil, fs.ErrNotExist
+	}
+	return e.fsys.Open(path)
+}
+
+func (e *exclude) ReadDir(dir string) (results []fs.DirEntry, err error) {
+	if e.fn(dir) {
+		return nil, fs.ErrNotExist
+	}
+	des, err := fs.ReadDir(e.fsys, dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, de := range des {
+		if e.fn(path.Join(dir, de.Name())) {
+			continue
+		}
+		results = append(results, de)
+	}
+	return results, nil
+}

--- a/package/virtual/exclude_test.go
+++ b/package/virtual/exclude_test.go
@@ -1,0 +1,31 @@
+package virtual_test
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/package/virtual"
+)
+
+func TestExclude(t *testing.T) {
+	is := is.New(t)
+	tree := virtual.Tree{
+		"view/a.txt": &virtual.File{Data: []byte("a")},
+		"view/b.txt": &virtual.File{Data: []byte("b")},
+		"bud/bud.go": &virtual.File{Data: []byte("bud")},
+	}
+	fsys := virtual.Exclude(tree, func(path string) bool {
+		fmt.Println(path, path == "bud" || strings.HasPrefix(path, "bud/"))
+		return path == "bud" || strings.HasPrefix(path, "bud/")
+	})
+	des, err := fs.ReadDir(fsys, ".")
+	is.Equal(err, nil)
+	for _, de := range des {
+		fmt.Println(de.Name())
+	}
+	is.Equal(len(des), 1)
+	is.Equal(des[0].Name(), "view")
+}

--- a/package/virtual/exclude_test.go
+++ b/package/virtual/exclude_test.go
@@ -1,7 +1,6 @@
 package virtual_test
 
 import (
-	"fmt"
 	"io/fs"
 	"strings"
 	"testing"
@@ -18,14 +17,10 @@ func TestExclude(t *testing.T) {
 		"bud/bud.go": &virtual.File{Data: []byte("bud")},
 	}
 	fsys := virtual.Exclude(tree, func(path string) bool {
-		fmt.Println(path, path == "bud" || strings.HasPrefix(path, "bud/"))
 		return path == "bud" || strings.HasPrefix(path, "bud/")
 	})
 	des, err := fs.ReadDir(fsys, ".")
 	is.Equal(err, nil)
-	for _, de := range des {
-		fmt.Println(de.Name())
-	}
 	is.Equal(len(des), 1)
 	is.Equal(des[0].Name(), "view")
 }

--- a/package/virtual/print.go
+++ b/package/virtual/print.go
@@ -1,0 +1,16 @@
+package virtual
+
+import (
+	"io/fs"
+
+	"github.com/livebud/bud/internal/printfs"
+)
+
+// Print out a virtual filesystem.
+func Print(fsys fs.FS) (string, error) {
+	tree, err := printfs.Walk(fsys)
+	if err != nil {
+		return "", err
+	}
+	return tree.String(), nil
+}


### PR DESCRIPTION
This PR adds support for custom generators. Custom generators allow you to define application-specific code generators that hook into the rest of the code generators. There was a first attempt at doing this in https://github.com/livebud/bud/pull/236, but it was subsequently removed in https://github.com/livebud/bud/pull/276 because the implementation had some tradeoffs so I looked for a better solution.

You can add a custom generator to you application by creating packages inside the `generator/` directory. For example, you can define the following package in `generator/tailwind/tailwind.go`

```go
package tailwind

import (
	"github.com/livebud/bud/package/budfs"
)

type Generator struct {
  // Dependencies
}

func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
	dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
		file.Data = []byte("/** tailwind **/")
		return nil
	})
	dir.GenerateFile("preflight.css", func(fsys budfs.FS, file *budfs.File) error {
		file.Data = []byte("/** preflight **/")
		return nil
	})
	return nil
}
```

Bud will then be able to find and run the function for `preflight.css` at `bud/internal/generator/tailwind/preflight.css`. Custom generators use the same `budfs` package that core generators like `controller` and `view` use.

While this PR introduces the ability to define your own custom generators, they're not exposed anywhere yet. The next step is to update other generators like `public` and `web` to look for custom generators and pull them into the build when they're in a certain directory. This will come in a follow-up PR.

Remaining todos for this PR:
- [x] Fix removing a file generator breaking the build (budfs should be able to remove paths too)