### PR TITLE
Add more test timeouts

### DIFF
--- a/framework/controller/controller_test.go
+++ b/framework/controller/controller_test.go
@@ -2028,9 +2028,9 @@ func TestControllerChange(t *testing.T) {
 		func (c *Controller) Index() string { return "/" }
 	`)), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Try again with the new file
 	res, err = app.GetJSON("/")
 	is.NoErr(err)
@@ -2788,7 +2788,10 @@ func TestCreateRouteAndControllerAndView(t *testing.T) {
 			return "/" + id
 		}
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	res, err = app.GetJSON("/10")
 	is.NoErr(err)
 	is.NoErr(res.Diff(`
@@ -2806,7 +2809,10 @@ func TestCreateRouteAndControllerAndView(t *testing.T) {
 			return "/posts"
 		}
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	res, err = app.GetJSON("/posts")
 	is.NoErr(err)
 	is.NoErr(res.Diff(`
@@ -2820,7 +2826,10 @@ func TestCreateRouteAndControllerAndView(t *testing.T) {
 	is.NoErr(os.WriteFile(filepath.Join(dir, "view", "posts", "index.svelte"), []byte(`
 		<h1>Posts</h1>
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	res, err = app.Get("/posts")
 	is.NoErr(err)
 	is.NoErr(res.DiffHeaders(`
@@ -2837,7 +2846,10 @@ func TestCreateRouteAndControllerAndView(t *testing.T) {
 	is.NoErr(os.WriteFile(filepath.Join(dir, "view", "posts", "show.svelte"), []byte(`
 		<h1>Show Posts</h1>
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	res, err = app.Get("/posts/10")
 	is.NoErr(err)
 	is.NoErr(res.DiffHeaders(`
@@ -2855,7 +2867,10 @@ func TestCreateRouteAndControllerAndView(t *testing.T) {
 		func (c *Controller) Show() {
 		}
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	res, err = app.Get("/posts/10")
 	is.NoErr(err)
 	is.NoErr(res.DiffHeaders(`
@@ -2926,7 +2941,10 @@ func TestDeleteRouteAndControllerAndView(t *testing.T) {
 	is.Equal(html, `<h1>Show Posts</h1>`)
 	// Delete the show view
 	is.NoErr(os.Remove(filepath.Join(dir, "view", "posts", "show.svelte")))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Try again
 	res, err = app.Get("/posts/10")
 	is.NoErr(err)
@@ -2937,7 +2955,10 @@ func TestDeleteRouteAndControllerAndView(t *testing.T) {
 	is.NotIn(res.Body().String(), "<h1>Show Posts</h1>")
 	// Delete the controller
 	is.NoErr(os.RemoveAll(filepath.Join(dir, "controller", "posts")))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Re-test /posts
 	res, err = app.Get("/posts")
 	is.NoErr(err)
@@ -2990,7 +3011,10 @@ func TestUpdateBodyAndSignatureAndRoute(t *testing.T) {
 			return "Hello Humans!"
 		}
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Retry
 	res, err = app.Get("/")
 	is.NoErr(err)
@@ -3007,7 +3031,10 @@ func TestUpdateBodyAndSignatureAndRoute(t *testing.T) {
 			return "Hello " + name + "!", nil
 		}
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Retry
 	res, err = app.Get("/?name=Mark")
 	is.NoErr(err)
@@ -3024,7 +3051,10 @@ func TestUpdateBodyAndSignatureAndRoute(t *testing.T) {
 			return "/"+id, nil
 		}
 	`), 0644))
-	is.NoErr(app.Ready(ctx))
+	// Wait for the app to be ready again
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Retry
 	res, err = app.Get("/?name=Mark")
 	is.NoErr(err)

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -221,9 +221,9 @@ func TestUpdateGenerator(t *testing.T) {
 		}
 	`)), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Check for preflight
 	data, err = os.ReadFile(td.Path("bud/internal/generator/tailwind/preflight.css"))
 	is.NoErr(err)
@@ -276,9 +276,9 @@ func TestRemoveGenerator(t *testing.T) {
 		}
 	`)), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Check that tailwind has been updated
 	data, err = os.ReadFile(td.Path("bud/internal/generator/tailwind/tailwind.css"))
 	is.True(os.IsNotExist(err))

--- a/framework/view/view_test.go
+++ b/framework/view/view_test.go
@@ -51,8 +51,8 @@ func TestHello(t *testing.T) {
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hi</h1>`), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Check that we received a hot reload event
 	event, err := hot.Next(ctx)
@@ -72,8 +72,8 @@ func TestHello(t *testing.T) {
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hola</h1>`), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Check that we received a hot reload event
 	event, err = hot.Next(ctx)
@@ -316,8 +316,8 @@ func TestRenameView(t *testing.T) {
 		filepath.Join(dir, "view/_show.svele"),
 	))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Check that we received a hot reload event
 	event, err := hot.Next(ctx)
@@ -371,8 +371,8 @@ func TestAddView(t *testing.T) {
 		<h1>{id}</h1>
 	`)), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Check that we received a hot reload event
 	event, err := hot.Next(ctx)

--- a/framework/view/view_test.go
+++ b/framework/view/view_test.go
@@ -51,7 +51,9 @@ func TestHello(t *testing.T) {
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hi</h1>`), 0644))
 	// Wait for the app to be ready again
-	app.Ready(ctx)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(ctx))
+	cancel()
 	// Check that we received a hot reload event
 	event, err := hot.Next(ctx)
 	is.NoErr(err)
@@ -70,7 +72,9 @@ func TestHello(t *testing.T) {
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hola</h1>`), 0644))
 	// Wait for the app to be ready again
-	app.Ready(ctx)
+	ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(ctx))
+	cancel()
 	// Check that we received a hot reload event
 	event, err = hot.Next(ctx)
 	is.NoErr(err)
@@ -121,8 +125,10 @@ func TestHelloEmbed(t *testing.T) {
 	indexFile := filepath.Join(dir, "view/index.svelte")
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hi</h1>`), 0644))
-	// Wait for the the app to be ready again
+	// Wait for the app to be ready again
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	is.NoErr(app.Ready(ctx))
+	cancel()
 	// Ensure that we got a hot reload event
 	event, err := hot.Next(ctx)
 	is.NoErr(err)
@@ -311,8 +317,8 @@ func TestRenameView(t *testing.T) {
 	))
 	// Wait for the app to be ready again
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	app.Ready(ctx)
+	is.NoErr(app.Ready(ctx))
+	cancel()
 	// Check that we received a hot reload event
 	event, err := hot.Next(ctx)
 	is.NoErr(err)
@@ -365,7 +371,9 @@ func TestAddView(t *testing.T) {
 		<h1>{id}</h1>
 	`)), 0644))
 	// Wait for the app to be ready again
-	app.Ready(ctx)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(ctx))
+	cancel()
 	// Check that we received a hot reload event
 	event, err := hot.Next(ctx)
 	is.NoErr(err)

--- a/framework/view/view_test.go
+++ b/framework/view/view_test.go
@@ -126,8 +126,8 @@ func TestHelloEmbed(t *testing.T) {
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hi</h1>`), 0644))
 	// Wait for the app to be ready again
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Ensure that we got a hot reload event
 	event, err := hot.Next(ctx)

--- a/framework/view/view_test.go
+++ b/framework/view/view_test.go
@@ -126,7 +126,7 @@ func TestHelloEmbed(t *testing.T) {
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))
 	is.NoErr(os.WriteFile(indexFile, []byte(`<h1>hi</h1>`), 0644))
 	// Wait for the app to be ready again
-	readyCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	readyCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Ensure that we got a hot reload event


### PR DESCRIPTION
Watching files in CI is still a bit flaky, so this allows the test to fail sooner.