### PR TITLE
Add 'bud tool fs tree [dir]' command

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livebud/bud/internal/cli/tooldi"
 	"github.com/livebud/bud/internal/cli/toolfscat"
 	"github.com/livebud/bud/internal/cli/toolfsls"
+	"github.com/livebud/bud/internal/cli/toolfstree"
 	"github.com/livebud/bud/internal/cli/toolfstxtar"
 	"github.com/livebud/bud/internal/cli/toolv8"
 	"github.com/livebud/bud/internal/cli/version"
@@ -131,6 +132,16 @@ func (c *CLI) Run(ctx context.Context, args ...string) error {
 				cli.Flag("hot", "hot reloading").Bool(&cmd.Flag.Hot).Default(true)
 				cli.Flag("minify", "minify assets").Bool(&cmd.Flag.Minify).Default(false)
 				cli.Arg("path").String(&cmd.Path)
+				cli.Run(cmd.Run)
+			}
+
+			{ // $ bud tool fs tree [dir]
+				cmd := toolfstree.New(cmd, c.in)
+				cli := cli.Command("tree", "list the file tree")
+				cli.Flag("embed", "embed assets").Bool(&cmd.Flag.Embed).Default(false)
+				cli.Flag("hot", "hot reloading").Bool(&cmd.Flag.Hot).Default(true)
+				cli.Flag("minify", "minify assets").Bool(&cmd.Flag.Minify).Default(false)
+				cli.Arg("dir").String(&cmd.Dir).Default(".")
 				cli.Run(cmd.Run)
 			}
 

--- a/internal/cli/toolfstree/toolfstree.go
+++ b/internal/cli/toolfstree/toolfstree.go
@@ -1,0 +1,59 @@
+package toolfstree
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+
+	"github.com/livebud/bud/internal/printfs"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/cli/bud"
+)
+
+func New(bud *bud.Command, in *bud.Input) *Command {
+	return &Command{
+		bud: bud,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
+	}
+}
+
+type Command struct {
+	bud  *bud.Command
+	Flag *framework.Flag
+	Dir  string
+}
+
+func (c *Command) Run(ctx context.Context) error {
+	log, err := bud.Log(c.Flag.Stdout, c.bud.Log)
+	if err != nil {
+		return err
+	}
+	dir := path.Clean(c.Dir)
+	module, err := bud.Module(path.Join(c.bud.Dir, dir))
+	if err != nil {
+		return err
+	}
+	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	if err != nil {
+		return err
+	}
+	defer bfs.Close()
+	subfs, err := fs.Sub(bfs, dir)
+	if err != nil {
+		return err
+	}
+	tree, err := printfs.Walk(subfs)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, tree.String())
+	return nil
+}

--- a/internal/cli/toolfstree/toolfstree.go
+++ b/internal/cli/toolfstree/toolfstree.go
@@ -3,7 +3,6 @@ package toolfstree
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"os"
 	"path"
 
@@ -46,14 +45,10 @@ func (c *Command) Run(ctx context.Context) error {
 		return err
 	}
 	defer bfs.Close()
-	subfs, err := fs.Sub(bfs, dir)
+	tree, err := printfs.Print(bfs, dir)
 	if err != nil {
 		return err
 	}
-	tree, err := printfs.Walk(subfs)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(os.Stdout, tree.String())
+	fmt.Fprintln(os.Stdout, tree)
 	return nil
 }

--- a/internal/printfs/printfs.go
+++ b/internal/printfs/printfs.go
@@ -51,92 +51,26 @@ func Walk(fsys fs.FS) (*Tree, error) {
 	return tree, nil
 }
 
-// func (t *Tree) String2() string {
-// 	// Handle special cases
-// 	switch len(t.entries) {
-// 	case 0:
-// 		return ""
-// 	case 1:
-// 		return strings.Join(t.entries[0].parts, sep)
-// 	}
-// 	// Sort the entries
-// 	sort.Slice(t.entries, func(i, j int) bool {
-// 		il := len(t.entries[i].parts)
-// 		ij := len(t.entries[j].parts)
-// 		lesser := il
-// 		if ij < il {
-// 			lesser = ij
-// 		}
-// 		for k := 0; k < lesser; k++ {
-// 			if t.entries[i].parts[k] < t.entries[j].parts[k] {
-// 				return true
-// 			}
-// 			if t.entries[i].parts[k] > t.entries[j].parts[k] {
-// 				return false
-// 			}
-// 		}
-// 		return il < ij
-// 	})
-
-// 	fmt.Println(0, t.entries[0].path)
-// 	prevPath := t.entries[0].path
-// 	depth := 0
-// 	for i := 1; i < len(t.entries); i++ {
-
-// 		currPath := t.entries[1].path
-// 		if strings.HasPrefix(currPath, prevPath) {
-// 			depth++
-// 		} else if !strings.HasPrefix(currPath, filepath.Dir(prevPath)) {
-// 			depth--
-// 		}
-// 		// fmt.Println(prev, curr, depth, t.entries[i].parts)
-// 		fmt.Println(depth, t.entries[i].path)
-// 		prevPath = currPath
-// 		// prevLen = currLen
-// 	}
-
-// 	// out := new(strings.Builder)
-// 	// prevDepth := len(t.entries[0].parts)
-// 	// depth := 0
-// 	// for i := 0; i < len(t.entries); i++ {
-// 	// 	if i > 0 {
-// 	// 		out.WriteByte('\n')
-// 	// 	}
-// 	// 	entry := t.entries[i]
-// 	// 	currDepth := len(entry.parts)
-// 	// 	if prevDepth < currDepth {
-// 	// 		depth++
-
-// 	// 	} else if prevDepth > currDepth {
-// 	// 		depth--
-// 	// 	}
-// 	// 	// Write the indent
-// 	// 	out.WriteString(indent(depth))
-// 	// 	if depth >= currDepth {
-// 	// 		out.WriteString(entry.parts[currDepth-1])
-// 	// 	} else {
-// 	// 		out.WriteString(strings.Join(entry.parts[depth:], sep))
-// 	// 	}
-// 	// 	// Write the /
-// 	// 	if entry.isDir {
-// 	// 		out.WriteString(sep)
-// 	// 	}
-// 	// 	prevDepth = currDepth
-// 	// }
-// 	return ""
-// 	// return out.String()
-// }
-
-// type entry struct {
-// 	path  string
-// 	parts []string
-// 	isDir bool
-// }
-
-// func indent(n int) string {
-// 	out := ""
-// 	for i := 0; i < n; i++ {
-// 		out += "  "
-// 	}
-// 	return out
-// }
+func Print(fsys fs.FS, dir string) (string, error) {
+	tree := New()
+	// Set the top-node
+	tree.tree.SetValue(dir)
+	subfs, err := fs.Sub(fsys, dir)
+	if err != nil {
+		return "", err
+	}
+	// Only walk the sub-tree
+	err = fs.WalkDir(subfs, ".", func(path string, de fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		} else if path == "." {
+			return nil
+		}
+		tree.Add(path)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return tree.String(), nil
+}


### PR DESCRIPTION
This PR adds the `bud tool fs tree` CLI subcommand. This command is helpful for getting an overview of the virtual file system's structure.

For example,

```sh
$ bud tool fs tree bud/
bud
└── internal
    ├── app
    │   ├── controller
    │   │   └── controller.go
    │   ├── main.go
    │   ├── public
    │   │   └── public.go
    │   ├── view
    │   │   └── view.go
    │   └── web
    │       └── web.go
    └── generator
        └── tailwind
```