### PR TITLE
package/budfs: add mount and fix a few bugs

### DIFF
--- a/package/remotefs/client.go
+++ b/package/remotefs/client.go
@@ -71,5 +71,6 @@ func (c *Client) Close() error {
 // isNotExist is needed because the error has been serialized and passed between
 // processes so errors.Is(err, fs.ErrNotExist) no longer is true.
 func isNotExist(err error) bool {
-	return strings.HasSuffix(err.Error(), fs.ErrNotExist.Error())
+	return strings.HasSuffix(err.Error(), fs.ErrNotExist.Error()) ||
+		strings.HasSuffix(err.Error(), "no such file or directory")
 }

--- a/package/remotefs/remotefs_test.go
+++ b/package/remotefs/remotefs_test.go
@@ -117,6 +117,23 @@ func TestNotExist(t *testing.T) {
 	is.Equal(data, nil)
 }
 
+func TestOSNotExist(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	ctx := context.Background()
+	server, err := listen(t)
+	is.NoErr(err)
+	defer server.Close()
+	client, err := remotefs.Dial(ctx, server.Addr().String())
+	is.NoErr(err)
+	fsys := os.DirFS(dir)
+	go remotefs.Serve(fsys, server)
+	data, err := fs.ReadFile(client, "client.go")
+	is.True(err != nil)
+	is.True(errors.Is(err, fs.ErrNotExist))
+	is.Equal(data, nil)
+}
+
 func TestCommand(t *testing.T) {
 	is := is.New(t)
 	parent := func(t testing.TB, cmd *exec.Cmd) {


### PR DESCRIPTION
Adds a `Mount` function to the bud filesystem. This will be used to better support application-specific generators.

This PR also fixes two internal bugs:
1. treefs: Root files should be checked for existence when running fs.ReadDir
2. remotefs: trying to read a non-existence real file (via os) should return an error that wraps `fs.ErrNotExist`.