### PR TITLE
package/budfs: reading the parent directory no longer triggers file generator

### DIFF
--- a/framework/controller/controller.go
+++ b/framework/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	// Embed templates
 
 	_ "embed"
+	"fmt"
 
 	"github.com/livebud/bud/internal/gotemplate"
 	"github.com/livebud/bud/package/budfs"
@@ -38,7 +39,7 @@ type Generator struct {
 func (g *Generator) GenerateFile(fsys budfs.FS, file *budfs.File) error {
 	state, err := Load(fsys, g.injector, g.module, g.parser)
 	if err != nil {
-		return err
+		return fmt.Errorf("framework/controller: unable to load. %w", err)
 	}
 	code, err := Generate(state)
 	if err != nil {

--- a/framework/generator/generator.go
+++ b/framework/generator/generator.go
@@ -47,7 +47,7 @@ func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
 	g.log.Debug("framework/generator: generating the main.go service containing the generators")
 	state, err := Load(fsys, g.injector, g.module, g.parser)
 	if err != nil {
-		return err
+		return fmt.Errorf("framework/generator: unable to load. %w", err)
 	}
 	code, err := Generate(state)
 	if err != nil {

--- a/internal/dsync/dsync.go
+++ b/internal/dsync/dsync.go
@@ -164,6 +164,10 @@ func createOps(opt *option, sfs fs.FS, dir string, des []fs.DirEntry) (ops []Op,
 		}
 		des, err := fs.ReadDir(sfs, path)
 		if err != nil {
+			// Ignore ReadDir that fail when the path doesn't exist
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
 			return nil, err
 		}
 		createOps, err := createOps(opt, sfs, path, des)

--- a/internal/dsync/dsync_test.go
+++ b/internal/dsync/dsync_test.go
@@ -179,13 +179,26 @@ func TestNoDuo(t *testing.T) {
 
 func TestSkipNotExist(t *testing.T) {
 	is := is.New(t)
-	// before := time.Date(2021, 8, 4, 14, 56, 0, 0, time.UTC)
-	after := time.Date(2021, 8, 4, 14, 57, 0, 0, time.UTC)
-	vfs.Now = func() time.Time { return after }
 
 	// starting points
 	sourceFS := treefs.New(".")
 	sourceFS.FileGenerator("bud/generate/main.go", treefs.Generate(func(target string) (fs.File, error) {
+		return nil, fs.ErrNotExist
+	}))
+	targetFS := vfs.Memory{}
+
+	// sync
+	err := dsync.To(sourceFS, targetFS, ".")
+	is.NoErr(err)
+	is.Equal(len(targetFS), 0)
+}
+
+func TestSkipDirNotExist(t *testing.T) {
+	is := is.New(t)
+
+	// starting points
+	sourceFS := treefs.New(".")
+	sourceFS.DirGenerator("bud/generate", treefs.Generate(func(target string) (fs.File, error) {
 		return nil, fs.ErrNotExist
 	}))
 	targetFS := vfs.Memory{}

--- a/package/budfs/budfs_test.go
+++ b/package/budfs/budfs_test.go
@@ -968,12 +968,20 @@ func TestReadDirNotExists(t *testing.T) {
 	fsys := virtual.Map{}
 	log := testlog.New()
 	bfs := budfs.New(fsys, log)
+	reads := 0
 	bfs.GenerateFile("bud/controller/controller.go", func(fsys budfs.FS, file *budfs.File) error {
+		reads++
 		return fs.ErrNotExist
 	})
+	// Generators aren't called on dirs, so the value is wrong until read or stat.
 	des, err := fs.ReadDir(bfs, "bud/controller")
 	is.NoErr(err)
-	is.Equal(len(des), 0)
+	is.Equal(len(des), 1)
+	is.Equal(reads, 0)
+	code, err := fs.ReadFile(bfs, "bud/controller/controller.go")
+	is.True(errors.Is(err, fs.ErrNotExist))
+	is.Equal(code, nil)
+	is.Equal(reads, 1)
 }
 
 func TestReadRootNotExists(t *testing.T) {
@@ -981,12 +989,20 @@ func TestReadRootNotExists(t *testing.T) {
 	fsys := virtual.Map{}
 	log := testlog.New()
 	bfs := budfs.New(fsys, log)
+	reads := 0
 	bfs.GenerateFile("controller.go", func(fsys budfs.FS, file *budfs.File) error {
+		reads++
 		return fs.ErrNotExist
 	})
+	// Generators aren't called on dirs, so the value is wrong until read or stat.
 	des, err := fs.ReadDir(bfs, ".")
 	is.NoErr(err)
-	is.Equal(len(des), 0)
+	is.Equal(len(des), 1)
+	is.Equal(reads, 0)
+	code, err := fs.ReadFile(bfs, "controller.go")
+	is.True(errors.Is(err, fs.ErrNotExist))
+	is.Equal(code, nil)
+	is.Equal(reads, 1)
 }
 
 func TestServeFile(t *testing.T) {

--- a/package/budfs/treefs/fillerdir.go
+++ b/package/budfs/treefs/fillerdir.go
@@ -1,7 +1,6 @@
 package treefs
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 
@@ -24,13 +23,6 @@ func (f *fillerDir) Generate(target string) (fs.File, error) {
 	// TODO: run in parallel
 	for _, child := range children {
 		de := &dirEntry{child}
-		// Stat to ensure the file exists before adding it as a directory entry
-		if _, err := de.Info(); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			}
-			return nil, err
-		}
 		entries = append(entries, de)
 	}
 	return virtual.New(&virtual.Dir{

--- a/package/budfs/treefs/treefs.go
+++ b/package/budfs/treefs/treefs.go
@@ -1,7 +1,6 @@
 package treefs
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"sort"
@@ -312,13 +311,6 @@ func (n *Node) open(target string) (fs.File, error) {
 		var entries []fs.DirEntry
 		for _, child := range children {
 			de := &dirEntry{child}
-			// Stat to ensure the file exists before adding it as a directory entry
-			if _, err := de.Info(); err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					continue
-				}
-				return nil, err
-			}
 			entries = append(entries, de)
 		}
 		return virtual.New(&virtual.Dir{

--- a/package/budfs/treefs/treefs_test.go
+++ b/package/budfs/treefs/treefs_test.go
@@ -277,3 +277,18 @@ func TestClear(t *testing.T) {
 `
 	is.Equal(n.Print(), expect)
 }
+
+func TestReadDir(t *testing.T) {
+	is := is.New(t)
+	n := treefs.New(".")
+	count := 0
+	n.FileGenerator("controller/controller.go", treefs.Generate(func(target string) (fs.File, error) {
+		count++
+		return nil, fs.ErrNotExist
+	}))
+	des, err := fs.ReadDir(n, "controller")
+	is.NoErr(err)
+	is.Equal(len(des), 1)
+	is.Equal(des[0].Name(), "controller.go")
+	is.Equal(count, 0)
+}


### PR DESCRIPTION
Prior to this PR, if you had a file generator at `bud/controller/controller.go` and you read the directory of `bud/controller`, it would run the generator for `bud/controller/controller.go`. Now reading a directory no longer runs the generator.

This makes it easier to have generators that depend on their subdirectories. This also seems like what you'd expect (why is the parent calling my generator?) and should also make when generators run a bit more predictable. 

There's a tradeoff here though. Now if you have:

```go
bfs.FileGenerator("bud/controller/controller.go", func(fsys budfs.FS, file *budfs.File) error {
  return nil, fs.ErrNotExist
})
```

And you read the `bud/controller` it will report 1 file, `controller.go`, but then when you go and read that file, it will say it doesn't exist. This PR adjusted the sync logic to make this case acceptable.