### PR TITLE
package/budfs: switch from fsys.Link to fsys.Watch

### DIFF
--- a/framework/view/dom/dom.go
+++ b/framework/view/dom/dom.go
@@ -65,8 +65,9 @@ func NodeModules(module *gomod.Module) budfs.FileGenerator {
 		if err != nil {
 			return err
 		}
-		for _, dep := range metafile.Dependencies() {
-			fsys.Link(dep)
+		// Watch the dependencies for changes
+		if err := fsys.Watch(metafile.Dependencies()...); err != nil {
+			return err
 		}
 		return nil
 	})
@@ -201,8 +202,9 @@ func (c *Compiler) GenerateFile(fsys budfs.FS, file *budfs.File) error {
 	if err != nil {
 		return err
 	}
-	for _, dep := range metafile.Dependencies() {
-		fsys.Link(dep)
+	// Watch the dependencies for changes
+	if err := fsys.Watch(metafile.Dependencies()...); err != nil {
+		return err
 	}
 	return nil
 }

--- a/framework/view/ssr/ssr.go
+++ b/framework/view/ssr/ssr.go
@@ -91,8 +91,9 @@ func (c *Compiler) Compile(ctx context.Context, fsys budfs.FS) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, dep := range metafile.Dependencies() {
-		fsys.Link(dep)
+	// Watch the dependencies for changes
+	if err := fsys.Watch(metafile.Dependencies()...); err != nil {
+		return nil, err
 	}
 	return result.OutputFiles[0].Contents, nil
 }

--- a/package/budfs/budfs.go
+++ b/package/budfs/budfs.go
@@ -380,11 +380,11 @@ var _ FS = (*fileSystem)(nil)
 
 // Open implements fs.FS
 func (f *fileSystem) Open(name string) (fs.File, error) {
+	f.link.Link("open", name)
 	file, err := f.fsys.Open(name)
 	if err != nil {
 		return nil, err
 	}
-	f.link.Link("open", name)
 	return file, nil
 }
 
@@ -452,13 +452,13 @@ func (f *fileSystem) Glob(pattern string) (matches []string, err error) {
 
 // ReadDir implements fs.ReadDirFS
 func (f *fileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	f.link.Select("readdir", func(path string) bool {
+		return path == name || filepath.Dir(path) == name
+	})
 	des, err := fs.ReadDir(f.fsys, name)
 	if err != nil {
 		return nil, err
 	}
-	f.link.Select("readdir", func(path string) bool {
-		return path == name || filepath.Dir(path) == name
-	})
 	return des, nil
 }
 

--- a/package/budfs/budfs_test.go
+++ b/package/budfs/budfs_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -1562,7 +1563,7 @@ func TestCyclesOk(t *testing.T) {
 	log := testlog.New()
 	bfs := budfs.New(fsys, log)
 	bfs.GenerateFile("a.txt", func(fsys budfs.FS, file *budfs.File) error {
-		fsys.Link("a.txt")
+		is.NoErr(fsys.Watch("a.txt"))
 		file.Data = []byte("a")
 		return nil
 	})
@@ -1573,6 +1574,64 @@ func TestCyclesOk(t *testing.T) {
 	code, err = fs.ReadFile(bfs, "a.txt")
 	is.NoErr(err)
 	is.Equal(string(code), "a")
+}
+
+func TestWatchGlob(t *testing.T) {
+	is := is.New(t)
+	fsys := virtual.Map{
+		"a.txt": &virtual.File{Data: []byte("a")},
+		"b.txt": &virtual.File{Data: []byte("b")},
+	}
+	log := testlog.New()
+	bfs := budfs.New(fsys, log)
+	count := map[string]int{}
+	bfs.GenerateFile("a.txt", func(fsys budfs.FS, file *budfs.File) error {
+		file.Data = []byte("a" + strconv.Itoa(count["a.txt"]))
+		count["a.txt"]++
+		return nil
+	})
+	bfs.GenerateFile("b.txt", func(fsys budfs.FS, file *budfs.File) error {
+		file.Data = []byte("b" + strconv.Itoa(count["b.txt"]))
+		count["b.txt"]++
+		return nil
+	})
+	bfs.GenerateFile("bud/c.txt", func(fsys budfs.FS, file *budfs.File) error {
+		is.NoErr(fsys.Watch("*.txt"))
+		a, err := fs.ReadFile(fsys, "a.txt")
+		is.NoErr(err)
+		b, err := fs.ReadFile(fsys, "b.txt")
+		is.NoErr(err)
+		file.Data = []byte("c" + strconv.Itoa(count["bud/c.txt"]) + string(a) + string(b))
+		count["bud/c.txt"]++
+		return nil
+	})
+	code, err := fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c0a0b0")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c0a0b0")
+	bfs.Change("a.txt")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c1a1b0")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c1a1b0")
+	bfs.Change("b.txt")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c2a1b1")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c2a1b1")
+	bfs.Change("b.txt", "a.txt")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c3a2b2")
+	code, err = fs.ReadFile(bfs, "bud/c.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "c3a2b2")
 }
 
 func TestServiceServe(t *testing.T) {


### PR DESCRIPTION
This PR changes the name from fsys.Link to fsys.Watch.

Additionally,
- Add support for passing in multiple paths at once.
- Add support for watching glob patterns.
- This also improves reactivity on single files.