### PR TITLE
framework/generator: mount generators from the root for more flexibility

### DIFF
--- a/internal/cli/bud/bud.go
+++ b/internal/cli/bud/bud.go
@@ -143,7 +143,7 @@ func FileSystem(ctx context.Context, log log.Interface, module *gomod.Module, fl
 	bfs.FileGenerator("bud/view/_ssr.js", ssr.New(module, transforms.SSR))
 	bfs.FileServer("bud/view", dom.New(module, transforms.DOM))
 	bfs.FileServer("bud/node_modules", dom.NodeModules(module))
-	bfs.DirGenerator("bud/internal/generator", generator.New(flag, injector, log, module, parser))
+	bfs.DirGenerator("bud/internal/generator", generator.New(bfs, flag, injector, log, module, parser))
 	return bfs, nil
 }
 


### PR DESCRIPTION
Internal prep work. 

Currently when you define generators, they all land in `bud/internal/generator/...`. This limits their discoverability by the other generators. This is the first step in allowing you to define generators anywhere.

