### PR TITLE
framework/generator: expand capabilities of generators with a generator.Register

### DIFF
--- a/framework/generator/generator.go
+++ b/framework/generator/generator.go
@@ -70,8 +70,8 @@ func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
 	builder.Env = append([]string{}, g.flag.Env...)
 	builder.Stderr = g.flag.Stderr
 	builder.Stdout = g.flag.Stdout
-	if err := builder.Build(fsys.Context(), "bud/command/generate/main.go", "bud/command/generate/main"); err != nil {
-		return fmt.Errorf("framework/generator: unable to build 'bud/command/generate/main'. %s", err)
+	if err := builder.Build(fsys.Context(), "bud/command/generate/main.go", "bud/generate"); err != nil {
+		return fmt.Errorf("framework/generator: unable to build 'bud/generate'. %s", err)
 	}
 
 	if g.process != nil {
@@ -82,14 +82,14 @@ func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
 		g.process = nil
 	}
 
-	g.log.Debug("framework/generator: start bud/command/generate/main that will serve the remote filesystem")
+	g.log.Debug("framework/generator: start bud/generate that will serve the remote filesystem")
 	cmd := &remotefs.Command{
 		Dir:    g.module.Directory(),
 		Env:    append([]string{}, g.flag.Env...),
 		Stderr: g.flag.Stderr,
 		Stdout: g.flag.Stdout,
 	}
-	g.process, err = cmd.Start(fsys.Context(), g.module.Directory("bud/command/generate/main"))
+	g.process, err = cmd.Start(fsys.Context(), g.module.Directory("bud/generate"))
 	if err != nil {
 		return err
 	}

--- a/framework/generator/generator.go
+++ b/framework/generator/generator.go
@@ -3,7 +3,6 @@ package generator
 import (
 	_ "embed"
 	"fmt"
-	"os"
 
 	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/internal/gobuild"
@@ -74,14 +73,6 @@ func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
 	if err := builder.Build(fsys.Context(), "bud/command/generate/main.go", "bud/command/generate/main"); err != nil {
 		return fmt.Errorf("framework/generator: unable to build 'bud/command/generate/main'. %s", err)
 	}
-	// Add the binary code to the filesystem.
-	binCode, err := os.ReadFile(g.module.Directory("bud/command/generate/main"))
-	if err != nil {
-		return err
-	}
-	dir.FileGenerator("main", &budfs.EmbedFile{
-		Data: binCode,
-	})
 
 	if g.process != nil {
 		g.log.Debug("framework/generator: closing existing process")

--- a/framework/generator/generator.gotext
+++ b/framework/generator/generator.gotext
@@ -54,10 +54,12 @@ func generate(ctx context.Context) error {
 		return err
 	}
 	bfs := budfs.New(module, log)
+	dir := bfs.Dir()
 	{{- range $generator := $.Generators }}
-	bfs.DirGenerator("bud/internal/generator/{{ $generator.Path }}", generators.{{ $generator.Pascal }})
+	log.Debug("framework/generator: registering {{ $generator.Path }}")
+	generators.{{ $generator.Pascal }}.Register(dir)
 	{{- end }}
-	log.Debug("framework/generator: serving remote 'bud/internal/generator' directory")
+	log.Debug("framework/generator: serving remote directory")
 	return remotefs.ServeFrom(ctx, bfs, "")
 }
 

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -24,16 +24,15 @@ func TestGenerators(t *testing.T) {
 			"github.com/livebud/bud/package/budfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+		func (g *Generator) Register(dir *budfs.Dir) {
+			dir.GenerateFile("bud/internal/generator/tailwind/tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("/** tailwind **/")
 				return nil
 			})
-			dir.GenerateFile("preflight.css", func(fsys budfs.FS, file *budfs.File) error {
+			dir.GenerateFile("bud/internal/generator/tailwind/preflight.css", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("/** preflight **/")
 				return nil
 			})
-			return nil
 		}
 	`
 	td.Files["internal/markdoc/markdoc.go"] = `
@@ -52,17 +51,21 @@ func TestGenerators(t *testing.T) {
 			"app.com/internal/markdoc"
 			"github.com/livebud/bud/package/budfs"
 			"io/fs"
+			"path/filepath"
 		)
 		type Generator struct {
 			Markdoc *markdoc.Compiler
 		}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			dir.GenerateFile("view/index.md", g.compile)
-			dir.GenerateFile("view/about/index.md", g.compile)
-			return nil
+		func (g *Generator) Register(dir *budfs.Dir) {
+			dir.GenerateFile("bud/internal/generator/markdoc/view/index.md", g.compile)
+			dir.GenerateFile("bud/internal/generator/markdoc/view/about/index.md", g.compile)
 		}
 		func (g *Generator) compile(fsys budfs.FS, file *budfs.File) error {
-			data, err := fs.ReadFile(fsys, file.Path())
+			relPath, err := filepath.Rel("bud/internal/generator/markdoc", file.Path())
+			if err != nil {
+				return err
+			}
+			data, err := fs.ReadFile(fsys, relPath)
 			if err != nil {
 				return err
 			}
@@ -81,19 +84,19 @@ func TestGenerators(t *testing.T) {
 		)
 		type Generator struct {
 		}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			dir.GenerateFile("viewer.go", func(fsys budfs.FS, file *budfs.File) error {
+		func (g *Generator) Register(dir *budfs.Dir) {
+			dir.GenerateFile("bud/internal/generator/web/viewer/viewer.go", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("package viewer")
 				return nil
 			})
-			return nil
 		}
 	`
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(dir)
 	_, err := cli.Run(ctx, "build", "--embed=false")
 	is.NoErr(err)
-	is.NoErr(td.Exists("bud/tmp/generate/main.go"))
+	is.NoErr(td.Exists("bud/command/generate/main.go"))
+	is.NoErr(td.Exists("bud/command/generate/main"))
 	is.NoErr(td.Exists("bud/internal/generator/tailwind/tailwind.css"))
 	is.NoErr(td.Exists("bud/internal/generator/tailwind/preflight.css"))
 	is.NoErr(td.Exists("bud/internal/generator/markdoc/view/index.md"))
@@ -127,11 +130,12 @@ func TestMissingGenerator(t *testing.T) {
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(dir)
 	_, err := cli.Run(ctx, "build", "--embed=false")
-	is.True(err != nil)
-	is.In(err.Error(), `generator: no Generator struct in "app.com/generator/web/transform"`)
+	is.NoErr(err)
+	is.NoErr(td.NotExists("bud/command/generate/main.go"))
+	is.NoErr(td.NotExists("bud/command/generate/main"))
 }
 
-func TestMissingGenerateDirMethod(t *testing.T) {
+func TestMissingRegisterMethod(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -144,8 +148,8 @@ func TestMissingGenerateDirMethod(t *testing.T) {
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(dir)
 	_, err := cli.Run(ctx, "build", "--embed=false")
-	is.True(err != nil)
-	is.In(err.Error(), `generator: no (*Generator).GenerateDir(...) method in "app.com/generator/web/transform"`)
+	is.NoErr(err)
+	is.NoErr(td.NotExists("bud/command/generate/main"))
 }
 
 func TestSyntaxError(t *testing.T) {
@@ -159,8 +163,8 @@ func TestSyntaxError(t *testing.T) {
 			"github.com/livebud/bud/package/budfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			return "not an error"
+		func (g *Generator) Register(dir *budfs.Dir) {
+			"ok"
 		}
 	`
 	is.NoErr(td.Write(ctx))
@@ -168,7 +172,7 @@ func TestSyntaxError(t *testing.T) {
 	res, err := cli.Run(ctx, "build", "--embed=false")
 	is.True(err != nil)
 	is.In(err.Error(), `exit status 2`)
-	is.In(res.Stderr(), `string does not implement error (missing Error method)`)
+	is.In(res.Stderr(), `"ok" (untyped string constant) is not used`)
 }
 
 func TestUpdateGenerator(t *testing.T) {
@@ -182,12 +186,11 @@ func TestUpdateGenerator(t *testing.T) {
 			"github.com/livebud/bud/package/budfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+		func (g *Generator) Register(dir *budfs.Dir) {
+			dir.GenerateFile("bud/internal/generator/tailwind/tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("/** tailwind **/")
 				return nil
 			})
-			return nil
 		}
 	`
 	is.NoErr(td.Write(ctx))
@@ -208,16 +211,15 @@ func TestUpdateGenerator(t *testing.T) {
 		)
 		type Generator struct {
 		}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+		func (g *Generator) Register(dir *budfs.Dir) {
+			dir.GenerateFile("bud/internal/generator/tailwind/tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("/** tailwind2 **/")
 				return nil
 			})
-			dir.GenerateFile("preflight.css", func(fsys budfs.FS, file *budfs.File) error {
+			dir.GenerateFile("bud/internal/generator/tailwind/preflight.css", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("/** preflight **/")
 				return nil
 			})
-			return nil
 		}
 	`)), 0644))
 	// Wait for the app to be ready again
@@ -245,12 +247,11 @@ func TestRemoveGenerator(t *testing.T) {
 			"github.com/livebud/bud/package/budfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			dir.GenerateFile("tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
+		func (g *Generator) Register(dir *budfs.Dir) {
+			dir.GenerateFile("bud/internal/generator/tailwind/tailwind.css", func(fsys budfs.FS, file *budfs.File) error {
 				file.Data = []byte("/** tailwind **/")
 				return nil
 			})
-			return nil
 		}
 	`
 	is.NoErr(td.Write(ctx))
@@ -271,8 +272,7 @@ func TestRemoveGenerator(t *testing.T) {
 		)
 		type Generator struct {
 		}
-		func (g *Generator) GenerateDir(fsys budfs.FS, dir *budfs.Dir) error {
-			return nil
+		func (g *Generator) Register(dir *budfs.Dir) {
 		}
 	`)), 0644))
 	// Wait for the app to be ready again

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -96,7 +96,6 @@ func TestGenerators(t *testing.T) {
 	_, err := cli.Run(ctx, "build", "--embed=false")
 	is.NoErr(err)
 	is.NoErr(td.Exists("bud/command/generate/main.go"))
-	is.NoErr(td.Exists("bud/command/generate/main"))
 	is.NoErr(td.Exists("bud/internal/generator/tailwind/tailwind.css"))
 	is.NoErr(td.Exists("bud/internal/generator/tailwind/preflight.css"))
 	is.NoErr(td.Exists("bud/internal/generator/markdoc/view/index.md"))

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -96,6 +96,7 @@ func TestGenerators(t *testing.T) {
 	_, err := cli.Run(ctx, "build", "--embed=false")
 	is.NoErr(err)
 	is.NoErr(td.Exists("bud/command/generate/main.go"))
+	is.NoErr(td.Exists("bud/generate"))
 	is.NoErr(td.Exists("bud/internal/generator/tailwind/tailwind.css"))
 	is.NoErr(td.Exists("bud/internal/generator/tailwind/preflight.css"))
 	is.NoErr(td.Exists("bud/internal/generator/markdoc/view/index.md"))
@@ -171,7 +172,8 @@ func TestSyntaxError(t *testing.T) {
 	res, err := cli.Run(ctx, "build", "--embed=false")
 	is.True(err != nil)
 	is.In(err.Error(), `exit status 2`)
-	is.In(res.Stderr(), `"ok" (untyped string constant) is not used`)
+	is.In(res.Stderr(), `"ok"`)
+	is.In(res.Stderr(), `not used`)
 }
 
 func TestUpdateGenerator(t *testing.T) {

--- a/internal/bfs/bfs.go
+++ b/internal/bfs/bfs.go
@@ -1,0 +1,83 @@
+package bfs
+
+import (
+	"errors"
+	"io/fs"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/framework/app"
+	"github.com/livebud/bud/framework/controller"
+	"github.com/livebud/bud/framework/generator"
+	"github.com/livebud/bud/framework/public"
+	"github.com/livebud/bud/framework/transform/transformrt"
+	"github.com/livebud/bud/framework/view"
+	"github.com/livebud/bud/framework/view/dom"
+	"github.com/livebud/bud/framework/view/ssr"
+	"github.com/livebud/bud/framework/web"
+	"github.com/livebud/bud/package/budfs"
+	"github.com/livebud/bud/package/di"
+	"github.com/livebud/bud/package/gomod"
+	v8 "github.com/livebud/bud/package/js/v8"
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/parser"
+	"github.com/livebud/bud/package/svelte"
+)
+
+func Load(flag *framework.Flag, log log.Interface, module *gomod.Module) (*FS, error) {
+	fsys := budfs.New(module, log)
+	parser := parser.New(fsys, module)
+	injector := di.New(fsys, log, module, parser)
+	vm, err := v8.Load()
+	if err != nil {
+		return nil, err
+	}
+	svelteCompiler, err := svelte.Load(vm)
+	if err != nil {
+		return nil, err
+	}
+	transforms, err := transformrt.Load(svelte.NewTransformable(svelteCompiler))
+	if err != nil {
+		return nil, err
+	}
+	fsys.FileGenerator("bud/internal/app/main.go", app.New(injector, module, flag))
+	fsys.FileGenerator("bud/internal/app/web/web.go", web.New(module, parser))
+	fsys.FileGenerator("bud/internal/app/controller/controller.go", controller.New(injector, module, parser))
+	fsys.FileGenerator("bud/internal/app/view/view.go", view.New(module, transforms, flag))
+	fsys.FileGenerator("bud/internal/app/public/public.go", public.New(flag, module))
+	fsys.FileGenerator("bud/view/_ssr.js", ssr.New(module, transforms.SSR))
+	fsys.FileServer("bud/view", dom.New(module, transforms.DOM))
+	fsys.FileServer("bud/node_modules", dom.NodeModules(module))
+	fsys.DirGenerator("bud/command/generate", generator.New(fsys, flag, injector, log, module, parser))
+	return &FS{fsys, module}, nil
+}
+
+type FS struct {
+	fsys   *budfs.FileSystem
+	module *gomod.Module
+}
+
+func (f *FS) Open(name string) (fs.File, error) {
+	return f.fsys.Open(name)
+}
+
+func (f *FS) Sync(to string) error {
+	if err := f.fsys.Sync(f.module, "bud/command/generate"); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+	}
+	if err := f.fsys.Sync(f.module, to); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *FS) Change(paths ...string) {
+	f.fsys.Change(paths...)
+}
+
+func (f *FS) Close() error {
+	return f.fsys.Close()
+}

--- a/internal/cli/build/build.go
+++ b/internal/cli/build/build.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/bfs"
 	"github.com/livebud/bud/internal/cli/bud"
 	"github.com/livebud/bud/internal/gobuild"
 	"github.com/livebud/bud/internal/versions"
@@ -46,13 +47,13 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	bfs, err := bfs.Load(c.Flag, log, module)
 	if err != nil {
 		return err
 	}
 	defer bfs.Close()
 	// Generate the application
-	if err := bfs.Sync(module, "bud/internal"); err != nil {
+	if err := bfs.Sync("bud/internal"); err != nil {
 		return err
 	}
 	builder := gobuild.New(module)

--- a/internal/cli/toolbs/toolbs.go
+++ b/internal/cli/toolbs/toolbs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/framework/web/webrt"
+	"github.com/livebud/bud/internal/bfs"
 	"github.com/livebud/bud/internal/cli/bud"
 	"github.com/livebud/bud/internal/pubsub"
 	"github.com/livebud/bud/package/budhttp/budsvr"
@@ -45,12 +46,12 @@ func (c *Command) Run(ctx context.Context) error {
 		return err
 	}
 	// Load the file server
-	servefs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	bfs, err := bfs.Load(c.Flag, log, module)
 	if err != nil {
 		return err
 	}
 	bus := pubsub.New()
-	server := budsvr.New(servefs, bus, log, vm)
+	server := budsvr.New(bfs, bus, log, vm)
 	budln, err := socket.Listen(":35729")
 	if err != nil {
 		return err

--- a/internal/cli/toolfscat/toolfscat.go
+++ b/internal/cli/toolfscat/toolfscat.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/bfs"
 	"github.com/livebud/bud/internal/cli/bud"
 )
 
@@ -40,7 +41,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	bfs, err := bfs.Load(c.Flag, log, module)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/toolfsls/toolfsls.go
+++ b/internal/cli/toolfsls/toolfsls.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/bfs"
 	"github.com/livebud/bud/internal/cli/bud"
 )
 
@@ -42,7 +43,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	bfs, err := bfs.Load(c.Flag, log, module)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/toolfstree/toolfstree.go
+++ b/internal/cli/toolfstree/toolfstree.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/livebud/bud/internal/bfs"
 	"github.com/livebud/bud/internal/printfs"
 
 	"github.com/livebud/bud/framework"
@@ -40,7 +41,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	bfs, err := bfs.Load(c.Flag, log, module)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/toolfstxtar/toolfstxtar.go
+++ b/internal/cli/toolfstxtar/toolfstxtar.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/tools/txtar"
 
 	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/bfs"
 	"github.com/livebud/bud/internal/cli/bud"
 )
 
@@ -43,7 +44,7 @@ func (c *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bfs, err := bud.FileSystem(ctx, log, module, c.Flag)
+	bfs, err := bfs.Load(c.Flag, log, module)
 	if err != nil {
 		return err
 	}

--- a/package/budfs/budfs.go
+++ b/package/budfs/budfs.go
@@ -199,6 +199,10 @@ func (f *FileSystem) Close() error {
 	return f.closer.Close()
 }
 
+func (f *FileSystem) Dir() *Dir {
+	return &Dir{fsys: f, node: f.node, target: "."}
+}
+
 type fileGenerator struct {
 	fsys *FileSystem
 	fn   func(fsys FS, file *File) error

--- a/package/budfs/budfs_test.go
+++ b/package/budfs/budfs_test.go
@@ -1777,3 +1777,22 @@ func TestServiceMount(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(string(code), "transforming: ssr-js/view/index.svelte")
 }
+
+func TestFileSystemDir(t *testing.T) {
+	is := is.New(t)
+	fsys := virtual.Map{}
+	log := testlog.New()
+	bfs := budfs.New(fsys, log)
+	dir := bfs.Dir()
+	is.Equal(dir.Target(), ".")
+	is.Equal(dir.Path(), ".")
+	is.Equal(dir.Mode(), fs.ModeDir)
+	dir.FileGenerator("a.txt", &budfs.EmbedFile{Data: []byte("a")})
+	dir.FileGenerator("b/b.txt", &budfs.EmbedFile{Data: []byte("b")})
+	code, err := fs.ReadFile(bfs, "a.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "a")
+	code, err = fs.ReadFile(bfs, "b/b.txt")
+	is.NoErr(err)
+	is.Equal(string(code), "b")
+}

--- a/package/finder/finder.go
+++ b/package/finder/finder.go
@@ -1,0 +1,45 @@
+package finder
+
+import (
+	"errors"
+	"io/fs"
+
+	"github.com/livebud/bud/internal/glob"
+	"github.com/livebud/bud/internal/orderedset"
+	"github.com/livebud/bud/internal/valid"
+)
+
+// Find files that match the pattern and are added as entries to the selector
+func Find(fsys fs.FS, pattern string, selector func(path string, isDir bool) (entries []string)) (matches []string, err error) {
+	matcher, err := glob.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	bases, err := glob.Bases(pattern)
+	if err != nil {
+		return nil, err
+	}
+	// Compute the matches for each base
+	for _, base := range bases {
+		// Walk the directory tree, filtering out non-valid paths
+		err = fs.WalkDir(fsys, base, valid.WalkDirFunc(func(path string, de fs.DirEntry, err error) error {
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
+				return err
+			} else if !matcher.Match(path) {
+				return nil
+			}
+			matches = append(matches, selector(path, de.IsDir())...)
+			return nil
+		}))
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+	}
+	return orderedset.Strings(matches...), nil
+}


### PR DESCRIPTION
Follow-up to: https://github.com/livebud/bud/pull/296

Generators can now generate anywhere. For example, you can define a generator in `generator/tailwind`:

```go
package tailwind

import (
	"github.com/livebud/bud/package/budfs"
)

type Generator struct {
	Compiler *tailwind.Compiler
}

func (g *Generator) Register(dir *budfs.Dir) {
	dir.GenerateFile("bud/internal/tailwind/tailwind.go", func(fsys budfs.FS, file *budfs.File) error {
		file.Data = []byte("package tailwind\n// compiled tailwind")
		return nil
	})
}
```
