### PR TITLE
framework/web: support custom web generators

### DIFF
--- a/framework/app/loader.go
+++ b/framework/app/loader.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Load(fsys fs.FS, injector *di.Injector, module *gomod.Module, flag *framework.Flag) (*State, error) {
-	if err := vfs.Exist(fsys, "bud/internal/app/web/web.go"); err != nil {
+	if err := vfs.Exist(fsys, "bud/internal/web/web.go"); err != nil {
 		return nil, err
 	}
 	return (&loader{
@@ -44,7 +44,7 @@ func (l *loader) Load() (state *State, err error) {
 	l.imports.AddNamed("console", "github.com/livebud/bud/package/log/console")
 	l.imports.AddNamed("log", "github.com/livebud/bud/package/log")
 	l.imports.AddNamed("filter", "github.com/livebud/bud/package/log/filter")
-	l.imports.Add(l.module.Import("bud/internal/app/web"))
+	l.imports.Add(l.module.Import("bud/internal/web"))
 	state.Provider = l.loadProvider()
 	state.Flag = l.flag
 	state.Imports = l.imports.List()
@@ -66,7 +66,7 @@ func (l *loader) loadProvider() *di.Provider {
 			{Import: "context", Type: "Context"},
 		},
 		Results: []di.Dependency{
-			di.ToType(l.module.Import("bud/internal/app/web"), "*Server"),
+			di.ToType(l.module.Import("bud/internal/web"), "*Server"),
 			&di.Error{},
 		},
 		Aliases: di.Aliases{

--- a/framework/controller/loader.go
+++ b/framework/controller/loader.go
@@ -262,7 +262,7 @@ func (l *loader) loadView(controllerKey, actionKey, actionRoute string) *View {
 		if base != key {
 			continue
 		}
-		l.imports.Add(l.module.Import("bud/internal/app/view"))
+		l.imports.Add(l.module.Import("bud/internal/web/view"))
 		return &View{
 			Route: actionRoute,
 		}

--- a/framework/public/public_test.go
+++ b/framework/public/public_test.go
@@ -16,12 +16,12 @@ func TestNoProject(t *testing.T) {
 	dir := t.TempDir()
 	td := testdir.New(dir)
 	cli := testcli.New(dir)
-	is.NoErr(td.NotExists("bud/internal/app/public"))
+	is.NoErr(td.NotExists("bud/internal/web/public"))
 	result, err := cli.Run(ctx)
 	is.NoErr(err)
 	is.In(result.Stdout(), "bud")
 	is.Equal(result.Stderr(), "")
-	is.NoErr(td.NotExists("bud/internal/app/public"))
+	is.NoErr(td.NotExists("bud/internal/web/public"))
 }
 
 func TestEmptyBuild(t *testing.T) {
@@ -31,13 +31,13 @@ func TestEmptyBuild(t *testing.T) {
 	td := testdir.New(dir)
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(dir)
-	is.NoErr(td.NotExists("bud/internal/app/public"))
+	is.NoErr(td.NotExists("bud/internal/web/public"))
 	result, err := cli.Run(ctx, "build")
 	is.NoErr(err)
 	is.In(result.Stdout(), "")
 	is.Equal(result.Stderr(), "")
 	// Empty builds don't generate public files
-	is.NoErr(td.NotExists("bud/internal/app/public"))
+	is.NoErr(td.NotExists("bud/internal/web/public"))
 }
 
 // Pulled from: https://github.com/mathiasbynens/small
@@ -135,12 +135,12 @@ func TestGetChangeGet(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(200, res.Status())
 	is.Equal(res.Body().Bytes(), favicon)
-	is.NoErr(td.Exists("bud/internal/app/public/public.go"))
+	is.NoErr(td.Exists("bud/internal/web/public/public.go"))
 	// Favicon2
 	favicon2 := []byte{0x00, 0x00, 0x01}
 	td.BFiles["public/favicon.ico"] = favicon2
 	is.NoErr(td.Write(ctx))
-	is.NoErr(td.Exists("bud/internal/app/public/public.go"))
+	is.NoErr(td.Exists("bud/internal/web/public/public.go"))
 	res, err = app.Get("/favicon.ico")
 	is.NoErr(err)
 	is.Equal(200, res.Status())

--- a/framework/view/view_test.go
+++ b/framework/view/view_test.go
@@ -45,7 +45,7 @@ func TestHello(t *testing.T) {
 		Content-Type: text/html
 	`))
 	is.In(res.Body().String(), "<h1>hello</h1>")
-	is.NoErr(td.Exists("bud/internal/app/view/view.go"))
+	is.NoErr(td.Exists("bud/internal/web/view/view.go"))
 	// Change svelte file
 	indexFile := filepath.Join(dir, "view/index.svelte")
 	is.NoErr(os.MkdirAll(filepath.Dir(indexFile), 0755))

--- a/framework/web/loader.go
+++ b/framework/web/loader.go
@@ -39,9 +39,9 @@ func (l *loader) Load() (state *State, err error) {
 	state = new(State)
 	// Ensure the web files exist
 	exist, err := vfs.SomeExist(l.fsys,
-		"bud/internal/app/controller/controller.go",
-		"bud/internal/app/public/public.go",
-		"bud/internal/app/view/view.go",
+		"bud/internal/web/controller/controller.go",
+		"bud/internal/web/public/public.go",
+		"bud/internal/web/view/view.go",
 	)
 	if err != nil {
 		return nil, err
@@ -59,19 +59,19 @@ func (l *loader) Load() (state *State, err error) {
 		return state, nil
 	}
 	// Turn on parts of the web server, based on what's generated
-	if exist["bud/internal/app/public/public.go"] {
+	if exist["bud/internal/web/public/public.go"] {
 		state.HasPublic = true
-		l.imports.AddNamed("public", l.module.Import("bud/internal/app/public"))
+		l.imports.AddNamed("public", l.module.Import("bud/internal/web/public"))
 	}
-	if exist["bud/internal/app/view/view.go"] {
+	if exist["bud/internal/web/view/view.go"] {
 		state.HasView = true
-		l.imports.AddNamed("view", l.module.Import("bud/internal/app/view"))
+		l.imports.AddNamed("view", l.module.Import("bud/internal/web/view"))
 	}
 	// Load the controllers
-	if exist["bud/internal/app/controller/controller.go"] {
+	if exist["bud/internal/web/controller/controller.go"] {
 		state.Actions = l.loadControllerActions()
 		if len(state.Actions) > 0 {
-			l.imports.AddNamed("controller", l.module.Import("bud/internal/app/controller"))
+			l.imports.AddNamed("controller", l.module.Import("bud/internal/web/controller"))
 		}
 	}
 	// state.Command = l.loadRoot("command")

--- a/framework/web/web.go
+++ b/framework/web/web.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	_ "embed"
+	"fmt"
 
 	"github.com/livebud/bud/internal/gotemplate"
 	"github.com/livebud/bud/package/budfs"
@@ -37,6 +38,7 @@ func (g *Generator) GenerateFile(fsys budfs.FS, file *budfs.File) error {
 	if err != nil {
 		return err
 	}
+	fmt.Println(string(code))
 	file.Data = code
 	return nil
 }

--- a/framework/web/web_test.go
+++ b/framework/web/web_test.go
@@ -16,11 +16,11 @@ func TestEmptyBuild(t *testing.T) {
 	td := testdir.New(dir)
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(dir)
-	is.NoErr(td.NotExists("bud/internal/app/web"))
+	is.NoErr(td.NotExists("bud/internal/web"))
 	result, err := cli.Run(ctx, "build")
 	is.NoErr(err)
 	is.Equal(result.Stdout(), "")
 	is.Equal(result.Stderr(), "")
 	// Empty builds generate the web directory
-	is.NoErr(td.Exists("bud/internal/app/web"))
+	is.NoErr(td.Exists("bud/internal/web"))
 }

--- a/internal/bfs/bfs.go
+++ b/internal/bfs/bfs.go
@@ -43,10 +43,10 @@ func Load(flag *framework.Flag, log log.Interface, module *gomod.Module) (*FS, e
 		return nil, err
 	}
 	fsys.FileGenerator("bud/internal/app/main.go", app.New(injector, module, flag))
-	fsys.FileGenerator("bud/internal/app/web/web.go", web.New(module, parser))
-	fsys.FileGenerator("bud/internal/app/controller/controller.go", controller.New(injector, module, parser))
-	fsys.FileGenerator("bud/internal/app/view/view.go", view.New(module, transforms, flag))
-	fsys.FileGenerator("bud/internal/app/public/public.go", public.New(flag, module))
+	fsys.FileGenerator("bud/internal/web/web.go", web.New(module, parser))
+	fsys.FileGenerator("bud/internal/web/controller/controller.go", controller.New(injector, module, parser))
+	fsys.FileGenerator("bud/internal/web/view/view.go", view.New(module, transforms, flag))
+	fsys.FileGenerator("bud/internal/web/public/public.go", public.New(flag, module))
 	fsys.FileGenerator("bud/view/_ssr.js", ssr.New(module, transforms.SSR))
 	fsys.FileServer("bud/view", dom.New(module, transforms.DOM))
 	fsys.FileServer("bud/node_modules", dom.NodeModules(module))

--- a/internal/gitignore/gitignore_test.go
+++ b/internal/gitignore/gitignore_test.go
@@ -13,7 +13,7 @@ func TestBudRoot(t *testing.T) {
 	ignore := gitignore.FromFS(fstest.MapFS{
 		".gitignore": &fstest.MapFile{Data: []byte(`/bud`)},
 	})
-	is.True(ignore("bud/internal/app/web/web.go"))
+	is.True(ignore("bud/internal/web/web.go"))
 	is.True(!ignore("main.go"))
 }
 

--- a/internal/glob/compile_test.go
+++ b/internal/glob/compile_test.go
@@ -14,3 +14,12 @@ func TestMatch(t *testing.T) {
 	is.True(matcher.Match("controller/controller.go"))
 	is.True(matcher.Match("view/index.svelte"))
 }
+
+func TestDirMatch(t *testing.T) {
+	is := is.New(t)
+	matcher, err := glob.Compile("controller/*/**.go")
+	is.NoErr(err)
+	is.True(!matcher.Match("controller/controller.go"))
+	is.True(matcher.Match("controller/view/view.go"))
+	is.True(matcher.Match("controller/public/public.go"))
+}

--- a/package/budfs/budfs_test.go
+++ b/package/budfs/budfs_test.go
@@ -1184,7 +1184,7 @@ func TestCacheGenerateFile(t *testing.T) {
 	count := map[string]int{}
 	fsys := &dirFS{count, dir}
 	bfs := budfs.New(fsys, log)
-	bfs.GenerateFile("bud/internal/app/view/view.go", func(fsys budfs.FS, file *budfs.File) error {
+	bfs.GenerateFile("bud/internal/web/view/view.go", func(fsys budfs.FS, file *budfs.File) error {
 		_, err := fs.Stat(fsys, "view/index.svelte")
 		if err != nil {
 			return err
@@ -1193,31 +1193,31 @@ func TestCacheGenerateFile(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		count["bud/internal/app/view/view.go"]++
+		count["bud/internal/web/view/view.go"]++
 		file.Data = []byte("package view")
 		return nil
 	})
-	bfs.GenerateFile("bud/internal/app/web/web.go", func(fsys budfs.FS, file *budfs.File) error {
-		_, err := fs.Stat(fsys, "bud/internal/app/view/view.go")
+	bfs.GenerateFile("bud/internal/web/web.go", func(fsys budfs.FS, file *budfs.File) error {
+		_, err := fs.Stat(fsys, "bud/internal/web/view/view.go")
 		if err != nil {
 			return err
 		}
-		count["bud/internal/app/web/web.go"]++
+		count["bud/internal/web/web.go"]++
 		file.Data = []byte("package web")
 		return nil
 	})
 
 	// Default state
-	is.Equal(count["bud/internal/app/web/web.go"], 0, "wrong web generator reads")
-	is.Equal(count["bud/internal/app/view/view.go"], 0, "wrong view generator reads")
+	is.Equal(count["bud/internal/web/web.go"], 0, "wrong web generator reads")
+	is.Equal(count["bud/internal/web/view/view.go"], 0, "wrong view generator reads")
 	is.Equal(count["view/index.svelte"], 0, "wrong index.svelte file reads")
 	is.Equal(count["view/about/index.svelte"], 0, "wrong about/index.svelte file reads")
 	// First sync
 	out := virtual.Map{}
 	err = bfs.Sync(out, "bud/internal")
 	is.NoErr(err)
-	is.Equal(count["bud/internal/app/web/web.go"], 1, "wrong web generator reads")
-	is.Equal(count["bud/internal/app/view/view.go"], 1, "wrong view generator reads")
+	is.Equal(count["bud/internal/web/web.go"], 1, "wrong web generator reads")
+	is.Equal(count["bud/internal/web/view/view.go"], 1, "wrong view generator reads")
 	is.Equal(count["view/index.svelte"], 1, "wrong index.svelte file reads")
 	is.Equal(count["view/about/index.svelte"], 1, "wrong about/index.svelte file reads")
 	// No change because we're only syncing generators and generators are cached
@@ -1225,16 +1225,16 @@ func TestCacheGenerateFile(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(count["view/index.svelte"], 1, "wrong index.svelte file reads")
 	is.Equal(count["view/about/index.svelte"], 1, "wrong about/index.svelte file reads")
-	is.Equal(count["bud/internal/app/view/view.go"], 1, "wrong view generator reads")
-	is.Equal(count["bud/internal/app/web/web.go"], 1, "wrong web generator reads")
+	is.Equal(count["bud/internal/web/view/view.go"], 1, "wrong view generator reads")
+	is.Equal(count["bud/internal/web/web.go"], 1, "wrong web generator reads")
 	// Increments real files because we're syncing everything, including the 2
 	// files directly. The generators still haven't run since the first run though.
 	err = bfs.Sync(out, ".")
 	is.NoErr(err)
 	is.Equal(count["view/index.svelte"], 2, "wrong index.svelte file reads")
 	is.Equal(count["view/about/index.svelte"], 2, "wrong about/index.svelte file reads")
-	is.Equal(count["bud/internal/app/view/view.go"], 1, "wrong view generator reads")
-	is.Equal(count["bud/internal/app/web/web.go"], 1, "wrong web generator reads")
+	is.Equal(count["bud/internal/web/view/view.go"], 1, "wrong view generator reads")
+	is.Equal(count["bud/internal/web/web.go"], 1, "wrong web generator reads")
 	// Generators gets re-run again and incremented, as well as the 2 files
 	// directly. However the files are only read once and cached, so they only
 	// increment by one, despite being read directly by the generator. Generators
@@ -1244,8 +1244,8 @@ func TestCacheGenerateFile(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(count["view/index.svelte"], 3, "wrong index.svelte file reads")
 	is.Equal(count["view/about/index.svelte"], 3, "wrong about/index.svelte file reads")
-	is.Equal(count["bud/internal/app/view/view.go"], 2, "wrong view generator reads")
-	is.Equal(count["bud/internal/app/web/web.go"], 2, "wrong web generator reads")
+	is.Equal(count["bud/internal/web/view/view.go"], 2, "wrong view generator reads")
+	is.Equal(count["bud/internal/web/web.go"], 2, "wrong web generator reads")
 }
 
 func TestCacheGenerateDir(t *testing.T) {


### PR DESCRIPTION
This PR allows custom generators to be picked up by the existing web generator and pulled in. This will be a low-level solution for middleware and custom routing. 

Still working out the details, but after this PR, you'll be able to define a generator in `bud/internal/web` with a certain API and the web generator will include that in its web server code. 