### PR TITLE
budhttp: budhttp.Client implements js.VM

### DIFF
--- a/framework/app/loader.go
+++ b/framework/app/loader.go
@@ -71,6 +71,7 @@ func (l *loader) loadProvider() *di.Provider {
 		},
 		Aliases: di.Aliases{
 			publicServer: di.ToType("github.com/livebud/bud/framework/public/publicrt", "*LiveServer"),
+			jsVM:         di.ToType("github.com/livebud/bud/package/budhttp", "Client"),
 		},
 	}
 	if l.flag.Embed {

--- a/package/budhttp/discard.go
+++ b/package/budhttp/discard.go
@@ -17,6 +17,14 @@ func (discard) Render(route string, props interface{}) (*ssr.Response, error) {
 	return nil, fmt.Errorf("budhttp: discard client does not support render")
 }
 
+func (discard) Script(path, script string) error {
+	return fmt.Errorf("budhttp: discard client does not support script")
+}
+
+func (discard) Eval(path, expression string) (string, error) {
+	return "", fmt.Errorf("budhttp: discard client does not support eval")
+}
+
 func (discard) Open(name string) (fs.File, error) {
 	return nil, fmt.Errorf("budhttp: discard client does not support open")
 }


### PR DESCRIPTION
This PR is prep work for https://github.com/livebud/bud/pull/300.

`budhttp.Client` is now a bit more low-level, implementing `js.VM` and `fs.FS` instead of being a renderer. This reduces the differences between the embedded and live views, so we can simplify the view runtime.