### PR TITLE
internal/dsync: fix bug where generators were not being deleted when returning fs.ErrNotExist

### DIFF
--- a/internal/dsync/dsync.go
+++ b/internal/dsync/dsync.go
@@ -114,8 +114,30 @@ func diff(opt *option, sfs fs.FS, sdir string, tfs vfs.ReadWritable, tdir string
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
-	sourceSet := set.New(sourceEntries...)
-	targetSet := set.New(targetEntries...)
+	// Create the source set from the source entries
+	sourceSet := set.NewWithSize(len(sourceEntries))
+	for _, de := range sourceEntries {
+		// Ensure all sources actually exist
+		if _, err := de.Info(); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		sourceSet.Add(de)
+	}
+	// Create a target set from the target entries
+	targetSet := set.NewWithSize(len(targetEntries))
+	for _, de := range targetEntries {
+		// Ensure all sources actually exist
+		if _, err := de.Info(); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		targetSet.Add(de)
+	}
 	creates := set.Difference(sourceSet, targetSet)
 	deletes := set.Difference(targetSet, sourceSet)
 	updates := set.Intersection(sourceSet, targetSet)


### PR DESCRIPTION
As part of the tradeoff made in https://github.com/livebud/bud/pull/293, `fs.ReadDir` no longer stats each directory entry to see if it exists. 

This leads to previously existing generators not being deleted when they return `fs.ErrNotExist`. 

This PR fixes dsync to cleanup those files that no longer exist.