### PR TITLE
Relax router inputs and remove automatic redirects.

### DIFF
--- a/package/router/radix/tree.go
+++ b/package/router/radix/tree.go
@@ -182,9 +182,9 @@ func (t *tree) insertAt(parent *node, tokens lex.Tokens, route string, handler h
 	// but not have a handler
 	if inTreeAlready {
 		// Error out if we have a handler that's exactly the same as another route
-		if parent.handler != nil {
-			return fmt.Errorf("radix: %q is already in the tree", route)
-		}
+		// if parent.handler != nil {
+		// 	return fmt.Errorf("radix: %q is already in the tree", route)
+		// }
 		parent.handler = handler
 		parent.route = route
 		return nil

--- a/package/router/radix/tree.go
+++ b/package/router/radix/tree.go
@@ -177,14 +177,9 @@ func (t *tree) insertAt(parent *node, tokens lex.Tokens, route string, handler h
 		parent.route = ""
 		return nil
 	}
-	// This set of tokens are already in the tree
-	// E.g. We've inserted "/a", "/b", then "/". "/" will already be in the tree
-	// but not have a handler
+	// This set of tokens are already in the tree. Override any prior handler if
+	// there was one.
 	if inTreeAlready {
-		// Error out if we have a handler that's exactly the same as another route
-		// if parent.handler != nil {
-		// 	return fmt.Errorf("radix: %q is already in the tree", route)
-		// }
 		parent.handler = handler
 		parent.route = route
 		return nil

--- a/package/router/radix/tree_test.go
+++ b/package/router/radix/tree_test.go
@@ -43,6 +43,7 @@ func handler(route string) http.Handler {
 
 func ok(t testing.TB, test *test) {
 	is := is.New(t)
+	is.Helper()
 	tree := radix.New()
 	for _, insert := range test.inserts {
 		err := tree.Insert(insert.route, handler(insert.route))
@@ -80,6 +81,7 @@ func ok(t testing.TB, test *test) {
 // ok checks that all permutations of the routes are ok
 // doesn't work with routes that contain "err".
 func okp(t testing.TB, test *test) {
+	t.Helper()
 	// Short tests shouldn't permutate
 	if testing.Short() {
 		ok(t, test)
@@ -100,23 +102,23 @@ func qs(slots radix.Slots) string {
 	return strings.Join(out, "&")
 }
 
-func TestDuplicates(t *testing.T) {
+func TestDuplicatesOk(t *testing.T) {
 	ok(t, &test{
 		inserts: []*insert{
 			{route: "/hi"},
-			{route: "/hi", err: `radix: "/hi" is already in the tree`},
+			{route: "/hi"},
 		},
 	})
 	ok(t, &test{
 		inserts: []*insert{
 			{route: "/users/:id"},
-			{route: "/users/:id", err: `radix: "/users/:id" is already in the tree`},
+			{route: "/users/:id"},
 		},
 	})
 	ok(t, &test{
 		inserts: []*insert{
 			{route: "/zap/:id/edit"},
-			{route: "/zap/:id/edit", err: `radix: "/zap/:id/edit" is already in the tree`},
+			{route: "/zap/:id/edit"},
 		},
 	})
 	okp(t, &test{
@@ -326,7 +328,7 @@ func TestOptional(t *testing.T) {
 		inserts: []*insert{
 			{route: "/:id?"},
 			{route: "/:a.:b?", err: `radix: ambiguous routes "/:a.:b?" and "/:id?"`},
-			{route: "/x:id?", err: `radix: "/x:id?" is already in the tree`},
+			{route: "/x:id?"},
 			{route: "/not/:last?/path", err: `route "/not/:last?/path": optional "?" must be at the end`},
 			{route: "/slash/:last?/", err: `route "/slash/:last?/": optional "?" must be at the end`},
 		},

--- a/package/router/router_test.go
+++ b/package/router/router_test.go
@@ -41,6 +41,7 @@ func handler(route string) http.Handler {
 
 func ok(t testing.TB, test *test) {
 	is := is.New(t)
+	is.Helper()
 	router := router.New()
 	for _, route := range test.routes {
 		if route.method == "" {
@@ -171,27 +172,38 @@ func TestTrailingSlash(t *testing.T) {
 	ok(t, &test{
 		routes: []*route{
 			{method: "GET", route: "/"},
-			{method: "GET", route: "/hi/", err: `route "/hi/": remove the slash "/" at the end`},
+			{method: "GET", route: "/hi/"},
 			{method: "GET", route: "/hi"},
 		},
 		requests: []*request{
 			{method: "GET", path: "/", status: 200},
-			{method: "GET", path: "/hi/", status: 308, location: "/hi", body: "<a href=\"/hi\">Permanent Redirect</a>.\n\n"},
-			{method: "GET", path: "/hi///", status: 308, location: "/hi", body: "<a href=\"/hi\">Permanent Redirect</a>.\n\n"},
+			{method: "GET", path: "/hi/", status: 200},
+			{method: "GET", path: "/hi///", status: 200},
 		},
 	})
 }
 func TestInsensitive(t *testing.T) {
 	ok(t, &test{
 		routes: []*route{
-			{method: "GET", route: "/HI", err: `route "/HI": uppercase letters are not allowed "H"`},
+			{method: "GET", route: "/HI"},
 			{method: "GET", route: "/hi"},
+			{method: "GET", route: "/Hi"},
+			{method: "GET", route: "/hI"},
+			{method: "GET", route: "/HI/"},
+			{method: "GET", route: "/hi/"},
+			{method: "GET", route: "/hI/"},
+			{method: "GET", route: "/Hi/"},
 		},
 		requests: []*request{
+			{method: "GET", path: "/hi", status: 200},
 			{method: "GET", path: "/HI", status: 200},
 			{method: "GET", path: "/Hi", status: 200},
 			{method: "GET", path: "/hI", status: 200},
-			{method: "GET", path: "/HI///", status: 308, location: "/HI", body: "<a href=\"/HI\">Permanent Redirect</a>.\n\n"},
+			{method: "GET", path: "/hi/", status: 200},
+			{method: "GET", path: "/HI/", status: 200},
+			{method: "GET", path: "/Hi/", status: 200},
+			{method: "GET", path: "/hI/", status: 200},
+			{method: "GET", path: "/HI///", status: 200},
 		},
 	})
 }


### PR DESCRIPTION
This PR allows the router to define routes that are uppercase, but get converted into case-insensitive routes when inserted into the radix tree.

Additionally, instead of erroring out on trailing slashes, we trim trailing slashes. 

Finally, instead of redirecting trailing slashes to the non-trailing slash variant, we'll expect folks to use the canonical meta tag to avoid distinct pages of the same content showing up in their analytics.

The reason for doing this now is to expose the chunk names in ESBuild which use a hash of uppercase characters.