### PR TITLE
package/trpipe: add initial trpipe for creating a pipeline of transformations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1
+	github.com/albertorestifo/dijkstra v0.0.0-20160910063646-aba76f725f72
 	github.com/bep/debounce v1.2.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/evanw/esbuild v0.14.11

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1 h1:8Qzi+0Uch1VJvdrOhJ8U8FqoPLbUdETPgMqGJ6DSMSQ=
 github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/albertorestifo/dijkstra v0.0.0-20160910063646-aba76f725f72 h1:uGeGZl8PxSq8VZGG4QK5njJTFA4/G/x5CYORvQVXtAE=
+github.com/albertorestifo/dijkstra v0.0.0-20160910063646-aba76f725f72/go.mod h1:o+JdB7VetTHjLhU0N57x18B9voDBQe0paApdEAEoEfw=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=

--- a/package/trpipe/trpipe.go
+++ b/package/trpipe/trpipe.go
@@ -1,0 +1,95 @@
+package trpipe
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/albertorestifo/dijkstra"
+	"github.com/livebud/bud/package/log"
+)
+
+func New(log log.Interface) *Pipeline {
+	return &Pipeline{
+		fns:   map[string][]func(file *File) error{},
+		graph: dijkstra.Graph{},
+		log:   log,
+	}
+}
+
+type Pipeline struct {
+	mu    sync.RWMutex
+	fns   map[string][]func(file *File) error
+	graph dijkstra.Graph
+	log   log.Interface
+}
+
+type File struct {
+	path string
+	ext  string
+	Data []byte
+}
+
+func (f *File) Path() string {
+	base := strings.TrimSuffix(f.path, filepath.Ext(f.path))
+	return base + f.ext
+}
+
+func (p *Pipeline) Add(from, to string, fn func(file *File) error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.fns[from]; !ok {
+		p.fns[from] = []func(file *File) error{}
+	}
+	key := from + ">" + to
+	p.fns[key] = append(p.fns[key], fn)
+	if p.graph[from] == nil {
+		p.graph[from] = map[string]int{}
+	}
+	if p.graph[to] == nil {
+		p.graph[to] = map[string]int{}
+	}
+	p.graph[from][to] = 1
+}
+
+func (p *Pipeline) Run(fromPath, toExt string, code []byte) ([]byte, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	fromExt := path.Ext(fromPath)
+	fmt.Println(fromPath, fromExt, toExt)
+	hops, _, err := p.graph.Path(fromExt, toExt)
+	if err != nil {
+		return nil, fmt.Errorf("trpipe: no path to transform %q to %q for %q. %w", fromExt, toExt, fromPath, err)
+	} else if len(hops) == 0 {
+		return code, nil
+	}
+	// Turn the hops into pairs (e.g. [ [.svelte, .js], ...])
+	pairs := [][2]string{[2]string{hops[0], hops[0]}}
+	for i := 1; i < len(hops); i++ {
+		pairs = append(pairs, [2]string{hops[i-1], hops[i]})
+		pairs = append(pairs, [2]string{hops[i], hops[i]})
+	}
+	file := &File{
+		path: fromPath,
+		ext:  fromExt,
+		Data: code,
+	}
+	// Apply transformations over the transform pairs
+	for _, pair := range pairs {
+		// Handle .svelte -> .svelte transformations
+		key := pair[0] + ">" + pair[1]
+		if transforms, ok := p.fns[key]; ok {
+			p.log.Debug("trpipe: running transforms", "key", key, "transforms", len(transforms))
+			for _, transform := range transforms {
+				if err := transform(file); err != nil {
+					return nil, err
+				}
+			}
+			// Update the extension
+			file.ext = pair[1]
+		}
+	}
+	return file.Data, nil
+}

--- a/package/trpipe/trpipe_test.go
+++ b/package/trpipe/trpipe_test.go
@@ -1,0 +1,89 @@
+package trpipe_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/package/log/testlog"
+	"github.com/livebud/bud/package/trpipe"
+)
+
+func TestSvelteJSX(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	pipe := trpipe.New(log)
+	trace := []string{}
+	pipe.Add(".svelte", ".jsx", func(file *trpipe.File) error {
+		trace = append(trace, "svelte->jsx")
+		file.Data = []byte(`export default function() { return ` + string(file.Data) + ` }`)
+		return nil
+	})
+	pipe.Add(".svelte", ".svelte", func(file *trpipe.File) error {
+		trace = append(trace, "svelte->svelte")
+		file.Data = []byte("<main>" + string(file.Data) + "</main>")
+		return nil
+	})
+	result, err := pipe.Run("hello.svelte", ".jsx", []byte("<h1>hi world</h1>"))
+	is.NoErr(err)
+	is.Equal(string(result), `export default function() { return <main><h1>hi world</h1></main> }`)
+	is.Equal(strings.Join(trace, " "), "svelte->svelte svelte->jsx")
+}
+
+func TestSvelteSvelte(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	pipe := trpipe.New(log)
+	trace := []string{}
+	pipe.Add(".svelte", ".svelte", func(file *trpipe.File) error {
+		trace = append(trace, "svelte->svelte")
+		file.Data = []byte("<main>" + string(file.Data) + "</main>")
+		return nil
+	})
+	result, err := pipe.Run("hello.svelte", ".svelte", []byte("<h1>hi world</h1>"))
+	is.NoErr(err)
+	is.Equal(string(result), `<main><h1>hi world</h1></main>`)
+	is.Equal(strings.Join(trace, " "), "svelte->svelte")
+}
+
+func TestNoPath(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	pipe := trpipe.New(log)
+	pipe.Add(".svelte", ".svelte", func(file *trpipe.File) error {
+		file.Data = []byte("<main>" + string(file.Data) + "</main>")
+		return nil
+	})
+	result, err := pipe.Run("hello.svelte", ".jsx", []byte("<h1>hi world</h1>"))
+	is.True(err != nil)
+	is.In(err.Error(), `trpipe: no path to transform ".svelte" to ".jsx" for "hello.svelte"`)
+	is.Equal(result, nil)
+}
+
+func TestMultiStep(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	pipe := trpipe.New(log)
+	trace := []string{}
+	pipe.Add(".svelte", ".jsx", func(file *trpipe.File) error {
+		trace = append(trace, "svelte->jsx")
+		file.Data = []byte(`export default function() { return ` + string(file.Data) + ` }`)
+		return nil
+	})
+	pipe.Add(".svelte", ".svelte", func(file *trpipe.File) error {
+		trace = append(trace, "svelte->svelte")
+		file.Data = []byte("<main>" + string(file.Data) + "</main>")
+		return nil
+	})
+	pipe.Add(".md", ".svelte", func(file *trpipe.File) error {
+		trace = append(trace, "md->svelte")
+		file.Data = bytes.TrimPrefix(file.Data, []byte("# "))
+		file.Data = []byte("<h1>" + string(file.Data) + "</h1>")
+		return nil
+	})
+	result, err := pipe.Run("hello.md", ".jsx", []byte("# hi world"))
+	is.NoErr(err)
+	is.Equal(string(result), `export default function() { return <main><h1>hi world</h1></main> }`)
+	is.Equal(strings.Join(trace, " "), "md->svelte svelte->svelte svelte->jsx")
+}


### PR DESCRIPTION
This package will be used by the transformer to create a pipeline of transforms, allowing you to transform from .md => .svelte => .js

It's not currently exposed yet, but I'm adding it to bud so it can be iterated on in place.