### PR TITLE
add 'bud generate' command

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/livebud/bud/internal/cli/bud"
 	"github.com/livebud/bud/internal/cli/build"
 	"github.com/livebud/bud/internal/cli/create"
+	"github.com/livebud/bud/internal/cli/generate"
 	"github.com/livebud/bud/internal/cli/newcontroller"
 	"github.com/livebud/bud/internal/cli/run"
 	"github.com/livebud/bud/internal/cli/toolbs"
@@ -63,6 +64,16 @@ func (c *CLI) Run(ctx context.Context, args ...string) error {
 		cli.Flag("hot", "hot reloading").Bool(&cmd.Flag.Hot).Default(true)
 		cli.Flag("minify", "minify assets").Bool(&cmd.Flag.Minify).Default(false)
 		cli.Flag("listen", "address to listen to").String(&cmd.Listen).Default(":3000")
+		cli.Run(cmd.Run)
+	}
+
+	{ // $ bud generate
+		cmd := generate.New(cmd, c.in)
+		cli := cli.Command("generate", "generate the code")
+		cli.Flag("embed", "embed assets").Bool(&cmd.Flag.Embed).Default(false)
+		cli.Flag("hot", "hot reloading").Bool(&cmd.Flag.Hot).Default(true)
+		cli.Flag("minify", "minify assets").Bool(&cmd.Flag.Minify).Default(false)
+		cli.Args("dirs").Strings(&cmd.Args)
 		cli.Run(cmd.Run)
 	}
 

--- a/internal/cli/generate/generate.go
+++ b/internal/cli/generate/generate.go
@@ -1,0 +1,74 @@
+package generate
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/bfs"
+	"github.com/livebud/bud/internal/cli/bud"
+	"github.com/livebud/bud/internal/versions"
+)
+
+// New command for bud generate
+func New(bud *bud.Command, in *bud.Input) *Command {
+	return &Command{
+		bud: bud,
+		in:  in,
+		Flag: &framework.Flag{
+			Env:    in.Env,
+			Stderr: in.Stderr,
+			Stdin:  in.Stdin,
+			Stdout: in.Stdout,
+		},
+	}
+}
+
+// Command for running bud generate
+type Command struct {
+	bud  *bud.Command
+	in   *bud.Input
+	Flag *framework.Flag
+	Args []string
+}
+
+// Run the generate command
+func (c *Command) Run(ctx context.Context) error {
+	// Find go.mod
+	module, err := bud.Module(c.bud.Dir)
+	if err != nil {
+		return err
+	}
+	// Ensure we have version alignment between the CLI and the runtime
+	if err := bud.EnsureVersionAlignment(ctx, module, versions.Bud); err != nil {
+		return err
+	}
+	// Setup the logger
+	log, err := bud.Log(c.in.Stderr, c.bud.Log)
+	if err != nil {
+		return err
+	}
+	// Load the filesystem
+	bfs, err := bfs.Load(c.Flag, log, module)
+	if err != nil {
+		return err
+	}
+	defer bfs.Close()
+	// Generate the application
+	if err := bfs.Sync(); err != nil {
+		return err
+	}
+	// Run go generate if we have any args
+	if len(c.Args) > 0 {
+		cmd := exec.CommandContext(ctx, "go", append([]string{"generate"}, c.Args...)...)
+		cmd.Dir = module.Directory()
+		cmd.Env = c.in.Env
+		cmd.Stdin = c.in.Stdin
+		cmd.Stdout = c.in.Stdout
+		cmd.Stderr = c.in.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a `bud generate` command. This command is almost exactly the same as `bud build` except it:

- uses the development flag defaults instead of the production flag defaults
- doesn't run `go build` at the end
- runs `go generate [args]` if there are arguments passed through