### PR TITLE
framework/transform2: add initial internal transform service support

### DIFF
--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -58,7 +58,7 @@ func (l *loader) Load(bfs budfs.FS) (state *State, err error) {
 }
 
 func (l *loader) loadGenerators(bfs budfs.FS) (generators []*UserGenerator) {
-	generatorDirs, err := finder.Find(bfs, "generator/**.go", func(path string, isDir bool) (entries []string) {
+	generatorDirs, err := finder.Find(bfs, "{generator/**.go,bud/internal/generator/**.go}", func(path string, isDir bool) (entries []string) {
 		if !isDir && valid.GoFile(path) {
 			entries = append(entries, filepath.Dir(path))
 		}

--- a/framework/transform2/loader.go
+++ b/framework/transform2/loader.go
@@ -1,0 +1,116 @@
+package transform
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/livebud/bud/package/di"
+
+	"github.com/livebud/bud/internal/bail"
+	"github.com/livebud/bud/internal/imports"
+	"github.com/livebud/bud/internal/scan"
+	"github.com/livebud/bud/internal/valid"
+	"github.com/livebud/bud/package/gomod"
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/parser"
+	"github.com/matthewmueller/gotext"
+	"github.com/matthewmueller/text"
+)
+
+func Load(fsys fs.FS, injector *di.Injector, log log.Log, module *gomod.Module, parser *parser.Parser) (*State, error) {
+	loader := &loader{
+		imports:  imports.New(),
+		injector: injector,
+		log:      log,
+		module:   module,
+		parser:   parser,
+	}
+	return loader.Load(fsys)
+}
+
+type loader struct {
+	bail.Struct
+	imports  *imports.Set
+	injector *di.Injector
+	log      log.Log
+	module   *gomod.Module
+	parser   *parser.Parser
+}
+
+// Load the command state
+func (l *loader) Load(fsys fs.FS) (state *State, err error) {
+	defer l.Recover2(&err, "transform")
+	// TODO: for cases like this, we just want to watch, we don't need to
+	// return the files.
+	if files, err := fs.Glob(fsys, "transform/**.go"); err != nil {
+		return nil, err
+	} else if len(files) == 0 {
+		return nil, fmt.Errorf("framework/transform: no transforms found. %w", fs.ErrNotExist)
+	}
+	state = new(State)
+	state.Transformers = l.loadTransformers(fsys)
+	l.imports.AddStd("fmt")
+	l.imports.AddNamed("log", "github.com/livebud/bud/package/log")
+	l.imports.AddNamed("budfs", "github.com/livebud/bud/package/budfs")
+	l.imports.AddNamed("transformrt", "github.com/livebud/bud/framework/transform2/transformrt")
+	state.Imports = l.imports.List()
+	return state, nil
+}
+
+func (l *loader) loadTransformers(fsys fs.FS) (transformers []*Transformer) {
+	transformDirs, err := scan.List(fsys, "transform", func(de fs.DirEntry) bool {
+		if de.IsDir() {
+			return valid.Dir(de.Name())
+		} else {
+			return valid.GoFile(de.Name())
+		}
+	})
+	if err != nil {
+		l.Bail(err)
+	} else if len(transformDirs) == 0 {
+		l.Bail(fmt.Errorf("framework/transform: no transforms found. %w", fs.ErrNotExist))
+	}
+	for _, transformDir := range transformDirs {
+		importPath := l.module.Import(transformDir)
+		pkg, err := l.parser.Parse(transformDir)
+		if err != nil {
+			l.Bail(err)
+		}
+		// Ensure the package has a transform
+		stct := pkg.Struct("Transform")
+		if stct == nil {
+			l.log.Warn("No Transform struct in %q. Skipping.", importPath)
+			continue
+		}
+		rootlessGenerator := strings.TrimPrefix(transformDir, "transform/")
+		transformers = append(transformers, &Transformer{
+			Import: &imports.Import{
+				Name: l.imports.Add(importPath),
+				Path: importPath,
+			},
+			Path:       rootlessGenerator,
+			Camel:      gotext.Camel(rootlessGenerator),
+			Transforms: l.loadTransforms(stct),
+		})
+	}
+	return transformers
+}
+
+func (l *loader) loadTransforms(stct *parser.Struct) (transforms []*Transform) {
+	for _, method := range stct.Methods() {
+		if method.Private() {
+			continue
+		}
+		parts := strings.SplitN(text.Lower(text.Space(method.Name())), " to ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		transforms = append(transforms, &Transform{
+			Name: method.Name(),
+			From: "." + text.Dot(parts[0]),
+			To:   "." + text.Dot(parts[1]),
+		})
+	}
+	return transforms
+}

--- a/framework/transform2/state.go
+++ b/framework/transform2/state.go
@@ -1,0 +1,24 @@
+package transform
+
+import (
+	"github.com/livebud/bud/internal/imports"
+)
+
+type State struct {
+	Imports      []*imports.Import
+	Transformers []*Transformer
+	// Provider     *di.Provider
+}
+
+type Transformer struct {
+	Import     *imports.Import
+	Path       string
+	Camel      string
+	Transforms []*Transform
+}
+
+type Transform struct {
+	From string // e.g. .svg
+	To   string // e.g. .svelte
+	Name string // e.g. SvgToSvelte
+}

--- a/framework/transform2/transform.go
+++ b/framework/transform2/transform.go
@@ -1,0 +1,53 @@
+package transform
+
+import (
+	_ "embed"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/gotemplate"
+	"github.com/livebud/bud/package/budfs"
+	"github.com/livebud/bud/package/di"
+	"github.com/livebud/bud/package/gomod"
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/parser"
+	"github.com/livebud/bud/package/remotefs"
+)
+
+//go:embed transform.gotext
+var template string
+
+var generator = gotemplate.MustParse("framework/transform/transform.gotext", template)
+
+// Generate the transform file
+func Generate(state *State) ([]byte, error) {
+	return generator.Generate(state)
+}
+
+// New transform generator
+func New(flag *framework.Flag, injector *di.Injector, log log.Log, module *gomod.Module, parser *parser.Parser) *Generator {
+	return &Generator{flag, injector, log, module, parser, nil}
+}
+
+type Generator struct {
+	flag     *framework.Flag
+	injector *di.Injector
+	log      log.Log
+	module   *gomod.Module
+	parser   *parser.Parser
+
+	process *remotefs.Process
+}
+
+func (g *Generator) GenerateFile(fsys budfs.FS, file *budfs.File) error {
+	g.log.Debug("framework/transform: generating the main.go service containing the generators")
+	state, err := Load(fsys, g.injector, g.log, g.module, g.parser)
+	if err != nil {
+		return err
+	}
+	code, err := Generate(state)
+	if err != nil {
+		return err
+	}
+	file.Data = code
+	return nil
+}

--- a/framework/transform2/transform.gotext
+++ b/framework/transform2/transform.gotext
@@ -1,0 +1,50 @@
+package transform
+
+{{- if $.Imports }}
+
+import (
+	{{- range $import := $.Imports }}
+	{{$import.Name}} "{{$import.Path}}"
+	{{- end }}
+)
+{{- end }}
+
+// Load the transformer
+func Load(
+	log log.Log,
+	{{- range $transformer := $.Transformers }}
+	{{ $transformer.Camel }} *{{ $transformer.Import.Name }}.Transform,
+	{{- end }}
+) *Generator {
+	transformer := transformrt.Load(
+		log,
+		{{- range $transformer := $.Transformers }}
+		{{- range $transform := $transformer.Transforms }}
+		&transformrt.Transform{
+			Import: "{{ $transformer.Import.Path }}",
+			From: "{{ $transform.From }}",
+			To: "{{ $transform.To }}",
+			Func: {{ $transformer.Camel }}.{{ $transform.Name }},
+		},
+		{{- end }}
+		{{- end }}
+	)
+	return &Generator{
+		transformer,
+	}
+}
+
+type Generator struct {
+	transformer *transformrt.Transformer
+}
+
+func (g *Generator) Register(dir *budfs.Dir) {
+	dir.ServeFile(`bud/service/transform`, func(fsys budfs.FS, file *budfs.File) error {
+		code, err := g.transformer.Transform(fsys, file.Relative())
+		if err != nil {
+			return fmt.Errorf("generator/transform: unable to transform %q. %w", file.Relative(), err)
+		}
+		file.Data = code
+		return nil
+	})
+}

--- a/framework/transform2/transform_test.go
+++ b/framework/transform2/transform_test.go
@@ -1,0 +1,210 @@
+package transform_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/livebud/bud/internal/bfs"
+	"github.com/livebud/bud/internal/cli/testcli"
+
+	"github.com/livebud/bud/package/log"
+
+	"github.com/livebud/bud/framework"
+
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/internal/testdir"
+	"github.com/livebud/bud/package/gomod"
+	"github.com/livebud/bud/package/log/testlog"
+)
+
+func loadBFS(log log.Log, module *gomod.Module) (*bfs.FS, error) {
+	flag := &framework.Flag{
+		Embed:  false,
+		Minify: false,
+		Hot:    true,
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Env:    os.Environ(),
+	}
+	return bfs.Load(flag, log, module)
+}
+
+func TestEmpty(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	_, err := cli.Run(ctx, "build", "--embed=false")
+	is.NoErr(err)
+	is.NoErr(td.NotExists("bud/internal/generator/transform"))
+}
+
+func TestSvelteToSvelte(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["view/index.svelte"] = `<h1>hello</h1>`
+	td.Files["transform/doubler/transform.go"] = `
+		package doubler
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		type Transform struct {}
+		func (t *Transform) SvelteToSvelte(file *transformrt.File) error {
+			file.Data = append(file.Data, file.Data...)
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	module, err := gomod.Find(dir)
+	is.NoErr(err)
+	bfs, err := loadBFS(log, module)
+	is.NoErr(err)
+	is.NoErr(bfs.Sync())
+	defer bfs.Close()
+	is.NoErr(td.Exists("bud/internal/generator/transform/transform.go"))
+	is.NoErr(td.NotExists("bud/service/transform"))
+	code, err := fs.ReadFile(bfs, "bud/service/transform/svelte/view/index.svelte")
+	is.NoErr(err)
+	is.Equal(string(code), `<h1>hello</h1><h1>hello</h1>`)
+}
+
+func TestSvelteToSvelteToJSX(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["view/index.svelte"] = `<h1>hello</h1>`
+	td.Files["transform/doubler/transform.go"] = `
+		package doubler
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		type Transform struct {}
+		func (t *Transform) SvelteToSvelte(file *transformrt.File) error {
+			file.Data = append(file.Data, file.Data...)
+			return nil
+		}
+	`
+	td.Files["transform/jsx/transform.go"] = `
+		package jsx
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		type Transform struct {}
+		func (t *Transform) SvelteToJsx(file *transformrt.File) error {
+			file.Data = []byte("export default function() { return <>" + string(file.Data) + "</> }")
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	module, err := gomod.Find(dir)
+	is.NoErr(err)
+	bfs, err := loadBFS(log, module)
+	is.NoErr(err)
+	is.NoErr(bfs.Sync())
+	defer bfs.Close()
+	code, err := fs.ReadFile(bfs, "bud/service/transform/jsx/view/index.svelte")
+	is.NoErr(err)
+	is.Equal(string(code), `export default function() { return <><h1>hello</h1><h1>hello</h1></> }`)
+}
+
+func TestFaviconToFavicon(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.BFiles["public/favicon.ico"] = []byte{0x01, 0x02, 0x03}
+	td.Files["transform/doubler/transform.go"] = `
+		package doubler
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		type Transform struct {}
+		func (t *Transform) SvelteToSvelte(file *transformrt.File) error {
+			file.Data = append(file.Data, file.Data...)
+			return nil
+		}
+		func (t *Transform) IcoToIco(file *transformrt.File) error {
+			file.Data = append(file.Data, file.Data...)
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	module, err := gomod.Find(dir)
+	is.NoErr(err)
+	bfs, err := loadBFS(log, module)
+	is.NoErr(err)
+	is.NoErr(bfs.Sync())
+	defer bfs.Close()
+	code, err := fs.ReadFile(bfs, "bud/service/transform/ico/public/favicon.ico")
+	is.NoErr(err)
+	is.Equal(code, []byte{0x01, 0x02, 0x03, 0x01, 0x02, 0x03})
+}
+
+func TestMdToSsrJsAndDomJs(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["view/index.md"] = `# hello`
+	td.Files["transform/svelte/transform.go"] = `
+		package svelte
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		type Transform struct {}
+		func (t *Transform) SvelteToSsrJs(file *transformrt.File) error {
+			file.Data = []byte("module.exports = function() { return " + string(file.Data) + " }")
+			return nil
+		}
+		func (t *Transform) SvelteToDomJs(file *transformrt.File) error {
+			file.Data = []byte("export default function() { return " + string(file.Data) + " }")
+			return nil
+		}
+	`
+	td.Files["transform/tailwind/transform.go"] = `
+		package tailwind
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		import "bytes"
+		type Transform struct {}
+		func (t *Transform) SvelteToSvelte(file *transformrt.File) error {
+			file.Data = bytes.Replace(file.Data, []byte("class='bg-red-100'"), []byte("style='color: red'"), -1)
+			return nil
+		}
+	`
+	td.Files["transform/markdoc/transform.go"] = `
+		package markdoc
+		import "github.com/livebud/bud/framework/transform2/transformrt"
+		import "bytes"
+		type Markdoc struct {}
+		func (m *Markdoc) Compile(data []byte) ([]byte, error) {
+			data = bytes.TrimPrefix(data, []byte("# "))
+			data = []byte("<h1 class='bg-red-100'>" + string(data) + "</h1>")
+			return data, nil
+		}
+		type Transform struct {
+			Markdoc *Markdoc
+		}
+		func (t *Transform) MdToSvelte(file *transformrt.File) (err error) {
+			file.Data, err = t.Markdoc.Compile(file.Data)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	module, err := gomod.Find(dir)
+	is.NoErr(err)
+	bfs, err := loadBFS(log, module)
+	is.NoErr(err)
+	is.NoErr(bfs.Sync())
+	defer bfs.Close()
+	code, err := fs.ReadFile(bfs, "bud/service/transform/ssr.js/view/index.md")
+	is.NoErr(err)
+	is.Equal(string(code), `module.exports = function() { return <h1 style='color: red'>hello</h1> }`)
+	code, err = fs.ReadFile(bfs, "bud/service/transform/dom.js/view/index.md")
+	is.NoErr(err)
+	is.Equal(string(code), `export default function() { return <h1 style='color: red'>hello</h1> }`)
+}

--- a/framework/transform2/transformrt/transformrt.go
+++ b/framework/transform2/transformrt/transformrt.go
@@ -1,0 +1,52 @@
+package transformrt
+
+import (
+	"io/fs"
+	"strings"
+
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/trpipe"
+)
+
+type File = trpipe.File
+
+type Transform struct {
+	Import string // import path
+	From   string
+	To     string
+	Func   func(file *File) error
+}
+
+func Load(log log.Log, transforms ...*Transform) *Transformer {
+	pipeline := trpipe.New(log)
+	for _, t := range transforms {
+		pipeline.Add(t.From, t.To, t.Func)
+	}
+	return &Transformer{pipeline}
+}
+
+type Transformer struct {
+	pipeline *trpipe.Pipeline
+}
+
+func (t *Transformer) Transform(fsys fs.FS, fpath string) ([]byte, error) {
+	fromPath, toExt := parsePath(fpath)
+	code, err := fs.ReadFile(fsys, fromPath)
+	if err != nil {
+		return nil, err
+	}
+	return t.pipeline.Run(fromPath, toExt, code)
+}
+
+func parsePath(fpath string) (fromPath, toExt string) {
+	root, rest := splitRoot(fpath)
+	return rest, "." + root
+}
+
+func splitRoot(dir string) (root, rest string) {
+	parts := strings.SplitN(dir, "/", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}


### PR DESCRIPTION
This PR is a follow-up to: https://github.com/livebud/bud/pull/288

This PR creates a "transform service" that you can add custom transforms to that can be used by other generators. The goal of this PR is to:
- Decouple transforms from generators and allow developers to bring their own transforms

This will enable:
- Custom views (e.g. index.md)
- Transpiler support (e.g. expanding tailwind classes to CSS)
- Custom imports (e.g. `import svgPath from "./something.svg"`)
- Static file transforms (e.g. minifying svgs using svgo)

The idea being that the public generator can request a file through the transform service:

```go
code, err := fs.ReadFile(fsys, "bud/service/transform/svg/public/favicon.svg")
```

And if there's an `IcoToIco` transform enabled, this favicon will pass through the .ico transform. The format of the transform service is the following:

```
bud/service/transform/{toExt}/{fromPath}
```

There's more details in https://github.com/livebud/bud/pull/288 for how the transform service works. This is still an internal change, but I intend to update the generators to take advantage of this service in the coming weeks.