### PR TITLE
framework/{controller,web}: register routes from within the controller

### DIFF
--- a/framework/app/app_test.go
+++ b/framework/app/app_test.go
@@ -20,11 +20,17 @@ func TestWelcome(t *testing.T) {
 	is.NoErr(td.NotExists("bud/app"))
 	app, err := cli.Start(ctx, "run")
 	is.NoErr(err)
+	// Test the index page
 	res, err := app.Get("/")
 	is.NoErr(err)
 	is.Equal(res.Status(), 200)
 	is.In(res.Body().String(), "Hey Bud")
 	is.In(res.Body().String(), "Hey Bud") // should work multiple times
+	// Test the client-side JS
+	res, err = app.Get("/bud/view/_index.svelte.js")
+	is.NoErr(err)
+	is.Equal(res.Status(), 200)
+	is.In(res.Body().String(), "Hey Bud")
 	is.Equal(app.Stdout(), "")
 	is.Equal(app.Stderr(), "")
 	is.NoErr(td.Exists("bud/app"))

--- a/framework/controller/controller.gotext
+++ b/framework/controller/controller.gotext
@@ -9,6 +9,14 @@ import (
 )
 {{- end }}
 
+type Handler struct {
+	*Controller
+}
+
+func (h *Handler) Register(r *router.Router) {
+	h.Controller.register(r)
+}
+
 {{- define "controller" }}
 
 // Controller struct
@@ -18,6 +26,15 @@ type {{ $.Pascal }}Controller struct {
 	{{- end }}
 	{{- range $controller := $.Controllers }}
 	{{$controller.Last.Pascal}}Controller *{{$controller.Pascal}}Controller
+	{{- end }}
+}
+
+func (c *{{ $.Pascal }}Controller) register(r *router.Router) {
+	{{- range $action := $.Actions }}
+	r.{{ $action.Method }}(`{{ $action.Route }}`, c.{{$action.Pascal}})
+	{{- end }}
+	{{- range $controller := $.Controllers }}
+	c.{{$controller.Last.Pascal}}Controller.register(r)
 	{{- end }}
 }
 
@@ -63,7 +80,7 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpRes
 	// Unmarshal the request body
 	if err := request.Unmarshal(httpRequest, &in); err != nil {
 		return &response.Format{
-			{{- if ne $action.Method "GET" }}
+			{{- if ne $action.Method "Get" }}
 			HTML: response.Status(http.StatusSeeOther).RedirectBack(httpRequest.URL.Path),
 			{{- end }}
 			JSON: response.Status(400).Set("Content-Type", "application/json").JSON(map[string]string{"error": err.Error()}),
@@ -82,7 +99,7 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpRes
 	{{- end }}
 	if err != nil {
 		return &response.Format{
-			{{- if ne $action.Method "GET" }}
+			{{- if ne $action.Method "Get" }}
 			HTML: response.Status(http.StatusSeeOther).RedirectBack(httpRequest.URL.Path),
 			{{- end }}
 			JSON: response.Status(500).Set("Content-Type", "application/json").JSON(map[string]string{"error": err.Error()}),
@@ -101,7 +118,7 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpRes
 	{{- if $action.Results.Error }}
 	if {{ $action.Results.Error }} != nil {
 		return &response.Format{
-			{{- if ne $action.Method "GET" }}
+			{{- if ne $action.Method "Get" }}
 			HTML: response.Status(http.StatusSeeOther).RedirectBack(httpRequest.URL.Path),
 			{{- end }}
 			JSON: response.Status(500).Set("Content-Type", "application/json").JSON(map[string]string{"error": {{ $action.Results.Error }}.Error()}),
@@ -111,7 +128,7 @@ func ({{$action.Short}} *{{ $.Pascal }}{{$action.Pascal}}Action) handler(httpRes
 
 	// Respond
 	return &response.Format{
-		{{- if eq $action.Method "GET" }}
+		{{- if eq $action.Method "Get" }}
 		{{- if $action.View }}
 		HTML: {{ $action.Short }}.View.Renderer("{{$action.View.Route}}", {{ $action.Results.ViewResult }}),
 		{{- else if $action.RespondHTML }}

--- a/framework/controller/loader.go
+++ b/framework/controller/loader.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net/http"
 	"path"
 	"sort"
 	"strconv"
@@ -55,6 +54,7 @@ func (l *loader) Load() (state *State, err error) {
 	state = new(State)
 	state.Controller = l.loadController("controller")
 	state.Providers = l.providers.List()
+	l.imports.AddNamed("router", "github.com/livebud/bud/package/router")
 	state.Imports = l.imports.List()
 	return state, nil
 }
@@ -228,17 +228,24 @@ func (l *loader) loadActionRoute(controllerRoute, actionName string) string {
 	}
 }
 
+const (
+	methodGet    = "Get"
+	methodPost   = "Post"
+	methodPatch  = "Patch"
+	methodDelete = "Delete"
+)
+
 // Method is the HTTP method for this controller
 func (l *loader) loadActionMethod(actionName string) string {
 	switch actionName {
 	case "Create":
-		return http.MethodPost
+		return methodPost
 	case "Update":
-		return http.MethodPatch
+		return methodPatch
 	case "Delete":
-		return http.MethodDelete
+		return methodDelete
 	default:
-		return http.MethodGet
+		return methodGet
 	}
 }
 
@@ -430,7 +437,7 @@ func (l *loader) loadActionResultFields(result *parser.Result, def parser.Declar
 // with better methods
 func (l *loader) loadActionRedirect(action *Action) string {
 	// Redirect for non-create methods is an empty string
-	if action.Method != http.MethodPost {
+	if action.Method != methodPost {
 		return `""`
 	}
 	results := action.Results

--- a/framework/web/loader.go
+++ b/framework/web/loader.go
@@ -54,8 +54,14 @@ func (l *loader) Load() (state *State, err error) {
 	l.imports.AddNamed("router", "github.com/livebud/bud/package/router")
 	// Show the welcome page if we don't have any web resources
 	if len(webDirs) == 0 {
-		l.imports.AddNamed("welcome", "github.com/livebud/bud/framework/web/welcome")
-		state.ShowWelcome = true
+		const importPath = "github.com/livebud/bud/framework/web/welcome"
+		state.Resources = append(state.Resources, &Resource{
+			Camel: "welcome",
+			Import: &imports.Import{
+				Name: l.imports.Add(importPath),
+				Path: importPath,
+			},
+		})
 		state.Imports = l.imports.List()
 		return state, nil
 	}

--- a/framework/web/loader.go
+++ b/framework/web/loader.go
@@ -4,9 +4,7 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
-	"strings"
 
-	"github.com/livebud/bud/internal/scan"
 	"github.com/livebud/bud/internal/valid"
 
 	"github.com/livebud/bud/internal/bail"
@@ -14,9 +12,7 @@ import (
 	"github.com/livebud/bud/package/finder"
 	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/parser"
-	"github.com/livebud/bud/package/vfs"
 	"github.com/matthewmueller/gotext"
-	"github.com/matthewmueller/text"
 )
 
 func Load(fsys fs.FS, module *gomod.Module, parser *parser.Parser) (*State, error) {
@@ -41,15 +37,7 @@ type loader struct {
 func (l *loader) Load() (state *State, err error) {
 	defer l.Recover(&err)
 	state = new(State)
-	// Ensure the web files exist
-	exist, err := vfs.SomeExist(l.fsys,
-		"bud/internal/web/controller/controller.go",
-		"bud/internal/web/public/public.go",
-		"bud/internal/web/view/view.go",
-	)
-	if err != nil {
-		return nil, err
-	}
+	// Load all the web handlers
 	webDirs, err := finder.Find(l.fsys, "bud/internal/web/*/**.go", func(path string, isDir bool) (entries []string) {
 		if !isDir && valid.GoFile(path) {
 			entries = append(entries, filepath.Dir(path))
@@ -59,34 +47,22 @@ func (l *loader) Load() (state *State, err error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = webDirs
 	// Add initial imports
 	l.imports.AddStd("net/http", "context")
 	l.imports.AddNamed("middleware", "github.com/livebud/bud/package/middleware")
 	l.imports.AddNamed("webrt", "github.com/livebud/bud/framework/web/webrt")
 	l.imports.AddNamed("router", "github.com/livebud/bud/package/router")
-	// Show the welcome page if we don't have controllers, views or public files
-	if len(exist) == 0 {
+	// Show the welcome page if we don't have any web resources
+	if len(webDirs) == 0 {
 		l.imports.AddNamed("welcome", "github.com/livebud/bud/framework/web/welcome")
 		state.ShowWelcome = true
 		state.Imports = l.imports.List()
 		return state, nil
 	}
-	// Turn on parts of the web server, based on what's generated
-	if exist["bud/internal/web/public/public.go"] {
-		state.Resources = append(state.Resources, l.loadResource("bud/internal/web/public"))
+	// Load the resources
+	for _, webDir := range webDirs {
+		state.Resources = append(state.Resources, l.loadResource(webDir))
 	}
-	if exist["bud/internal/web/view/view.go"] {
-		state.Resources = append(state.Resources, l.loadResource("bud/internal/web/view"))
-	}
-	// Load the controllers
-	if exist["bud/internal/web/controller/controller.go"] {
-		state.Actions = l.loadControllerActions()
-		if len(state.Actions) > 0 {
-			l.imports.AddNamed("controller", l.module.Import("bud/internal/web/controller"))
-		}
-	}
-	// state.Command = l.loadRoot("command")
 	// Load the imports
 	state.Imports = l.imports.List()
 	return state, nil
@@ -102,108 +78,4 @@ func (l *loader) loadResource(webDir string) (resource *Resource) {
 	packageName := path.Base(webDir)
 	resource.Camel = gotext.Camel(packageName)
 	return resource
-}
-
-func (l *loader) loadControllerActions() (actions []*Action) {
-	subfs, err := fs.Sub(l.fsys, "controller")
-	if err != nil {
-		l.Bail(err)
-	}
-	scanner := scan.Controllers(subfs)
-	for scanner.Scan() {
-		actions = append(actions, l.loadActions(scanner.Text())...)
-	}
-	if scanner.Err() != nil {
-		l.Bail(err)
-	}
-	return actions
-}
-
-func (l *loader) loadActions(dir string) (actions []*Action) {
-	pkg, err := l.parser.Parse(path.Join("controller", dir))
-	if err != nil {
-		l.Bail(err)
-	}
-	stct := pkg.Struct("Controller")
-	if stct == nil {
-		return nil
-	}
-	basePath := toBasePath(dir)
-	for _, method := range stct.PublicMethods() {
-		action := new(Action)
-		actionName := method.Name()
-		action.Method = l.loadActionMethod(actionName)
-		action.Route = l.loadActionRoute(l.loadControllerRoute(basePath), actionName)
-		action.CallName = l.loadActionCallName(basePath, actionName)
-		actions = append(actions, action)
-	}
-	return actions
-}
-
-func toBasePath(dir string) string {
-	if dir == "." {
-		return "/"
-	}
-	return "/" + dir
-}
-
-// Method is the HTTP method for this controller
-func (l *loader) loadActionMethod(name string) string {
-	switch name {
-	case "Create":
-		return "Post"
-	case "Update":
-		return "Patch"
-	case "Delete":
-		return "Delete"
-	default:
-		return "Get"
-	}
-}
-
-func (l *loader) loadControllerRoute(controllerPath string) string {
-	segments := strings.Split(text.Path(controllerPath), "/")
-	path := new(strings.Builder)
-	for i := 0; i < len(segments); i++ {
-		if i%2 != 0 {
-			path.WriteString("/")
-			path.WriteString(":" + text.Slug(text.Singular(segments[i-1])) + "_id")
-			path.WriteString("/")
-		}
-		path.WriteString(text.Slug(segments[i]))
-	}
-	return "/" + path.String()
-}
-
-// Route to the action
-func (l *loader) loadActionRoute(basePath, actionName string) string {
-	switch actionName {
-	case "Show", "Update", "Delete":
-		return path.Join(basePath, ":id")
-	case "New":
-		return path.Join(basePath, "new")
-	case "Edit":
-		return path.Join(basePath, ":id", "edit")
-	case "Index", "Create":
-		return basePath
-	default:
-		return path.Join(basePath, text.Lower(text.Snake(actionName)))
-	}
-}
-
-func (l *loader) loadActionCallName(basePath, actionName string) string {
-
-	splitPath := strings.Split(text.Title(basePath), " ")
-	for i, controller := range splitPath {
-		// append controller to every controller base name
-		if len(controller) > 0 {
-			splitPath[i] = controller + "Controller"
-		}
-	}
-	baseCaller := strings.Join(splitPath, ".")
-
-	if baseCaller == "" {
-		return actionName
-	}
-	return baseCaller + "." + actionName
 }

--- a/framework/web/state.go
+++ b/framework/web/state.go
@@ -5,14 +5,10 @@ import "github.com/livebud/bud/internal/imports"
 type State struct {
 	Imports   []*imports.Import
 	Resources []*Resource
-
-	// TODO: remove below
-	ShowWelcome bool
 }
 
 // Resource is a web package that will register its routes
 type Resource struct {
 	Import *imports.Import
-	Path   string
 	Camel  string
 }

--- a/framework/web/state.go
+++ b/framework/web/state.go
@@ -7,8 +7,6 @@ type State struct {
 	Resources []*Resource
 
 	// TODO: remove below
-	Actions     []*Action
-	HasView     bool
 	ShowWelcome bool
 }
 
@@ -17,11 +15,4 @@ type Resource struct {
 	Import *imports.Import
 	Path   string
 	Camel  string
-}
-
-// TODO: remove action
-type Action struct {
-	Method   string
-	Route    string
-	CallName string
 }

--- a/framework/web/web.gotext
+++ b/framework/web/web.gotext
@@ -14,12 +14,6 @@ import (
 // New web server
 func New(
 	router *router.Router,
-	{{- if $.Actions }}
-	controller *controller.Controller,
-	{{- end }}
-	{{/* {{- if $.HasView }}
-	view view.Server,
-	{{- end }} */}}
 	{{- if $.ShowWelcome }}
 	welcome welcome.Middleware,
 	{{- end }}
@@ -27,12 +21,6 @@ func New(
 	{{ $resource.Camel }} *{{ $resource.Import.Name }}.Handler,
 	{{- end }}
 ) *Server {
-	{{- if $.Actions }}
-	// Action routing
-	{{- range $action := $.Actions }}
-	router.{{ $action.Method }}(`{{ $action.Route }}`, controller.{{ $action.CallName }})
-	{{- end }}
-	{{- end }}
 	{{- if $.Resources }}
 	// Register routes
 	{{- range $resource := $.Resources }}
@@ -46,9 +34,6 @@ func New(
 		{{- if $.ShowWelcome }}
 		welcome,
 		{{- end }}
-		{{/* {{- if $.HasView }}
-		view,
-		{{- end }} */}}
 	)
 	// 404 at the bottom of the middleware
 	handler := middleware.Middleware(http.NotFoundHandler())

--- a/framework/web/web.gotext
+++ b/framework/web/web.gotext
@@ -14,9 +14,6 @@ import (
 // New web server
 func New(
 	router *router.Router,
-	{{- if $.ShowWelcome }}
-	welcome welcome.Middleware,
-	{{- end }}
 	{{- range $resource := $.Resources }}
 	{{ $resource.Camel }} *{{ $resource.Import.Name }}.Handler,
 	{{- end }}
@@ -31,12 +28,10 @@ func New(
 	middleware := middleware.Compose(
 		middleware.MethodOverride(),
 		router,
-		{{- if $.ShowWelcome }}
-		welcome,
-		{{- end }}
 	)
 	// 404 at the bottom of the middleware
 	handler := middleware.Middleware(http.NotFoundHandler())
+	// Return the web server
 	return &Server{handler}
 }
 

--- a/framework/web/welcome/welcome.go
+++ b/framework/web/welcome/welcome.go
@@ -1,30 +1,65 @@
 package welcome
 
 import (
-	"embed"
+	_ "embed"
+	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 
-	"github.com/livebud/bud/package/middleware"
+	"github.com/livebud/bud/package/router"
+	"github.com/livebud/bud/package/virtual"
 )
 
 // Files are built in https://github.com/livebud/welcome and manually copied
 // over.
-//
-//go:embed build/index.html build/bud/view/_index.svelte.js
-var embeds embed.FS
 
-func Load() (Middleware, error) {
-	fsys, err := fs.Sub(embeds, "build")
-	if err != nil {
-		return nil, err
-	}
-	server := http.FileServer(http.FS(fsys))
-	return middleware.Function(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			server.ServeHTTP(w, r)
-		})
-	}), nil
+//go:embed build/index.html
+var index []byte
+
+//go:embed build/bud/view/_index.svelte.js
+var clientJS []byte
+
+type Handler struct {
 }
 
-type Middleware = middleware.Middleware
+func (h *Handler) Register(r *router.Router) {
+	handle := handler(http.FS(&virtual.Map{
+		".": &virtual.File{
+			Path: "index.html",
+			Data: index,
+		},
+		"bud/view/_index.svelte.js": &virtual.File{
+			Path: "bud/view/_index.svelte.js",
+			Data: clientJS,
+		},
+	}))
+	r.Get("/", handle)
+	r.Get("/bud/view/_index.svelte.js", handle)
+}
+
+func handler(fsys http.FileSystem) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		file, err := fsys.Open(r.URL.Path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				http.NotFound(w, r)
+				return
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer file.Close()
+		stat, err := file.Stat()
+		if err != nil {
+			fmt.Println(err.Error())
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		if stat.IsDir() {
+			http.Error(w, fmt.Sprintf("%q is a directory", r.URL.Path), 500)
+			return
+		}
+		http.ServeContent(w, r, r.URL.Path, stat.ModTime(), file)
+	})
+}


### PR DESCRIPTION
This is the final part of https://github.com/livebud/bud/pull/309

The generated controller now contributes routes to the web generator. By abstracting out the web generator, you'll be able to contribute other routes to the web generator.