### PR TITLE
internal/errs: fix error chaining. 

### DIFF
--- a/framework/transform2/transform.gotext
+++ b/framework/transform2/transform.gotext
@@ -21,7 +21,6 @@ func Load(
 		{{- range $transformer := $.Transformers }}
 		{{- range $transform := $transformer.Transforms }}
 		&transformrt.Transform{
-			Import: "{{ $transformer.Import.Path }}",
 			From: "{{ $transform.From }}",
 			To: "{{ $transform.To }}",
 			Func: {{ $transformer.Camel }}.{{ $transform.Name }},

--- a/framework/transform2/transformrt/transformrt.go
+++ b/framework/transform2/transformrt/transformrt.go
@@ -11,12 +11,9 @@ import (
 type File = trpipe.File
 
 type Transform struct {
-	// TODO: figure out why import is need in the runtime
-	// Shouldn't this be in the generator?
-	Import string // import path
-	From   string
-	To     string
-	Func   func(file *File) error
+	From string
+	To   string
+	Func func(file *File) error
 }
 
 func Load(log log.Log, transforms ...*Transform) *Transformer {

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,17 +1,22 @@
 // Package errs makes it easier to join multiple errors into a single error.
 package errs
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Join multiple errors together into one error
-func Join(errors ...error) error {
+func Join(errs ...error) error {
 	var agg error
-	for _, err := range errors {
+	for _, err := range errs {
 		if err == nil {
 			continue
 		} else if agg == nil {
 			agg = err
 			continue
+		} else if errors.Is(err, agg) {
+			agg = fmt.Errorf("%w. %s", agg, err)
 		} else {
 			agg = fmt.Errorf("%s. %s", agg, err)
 		}

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -24,7 +24,15 @@ func TestOne(t *testing.T) {
 func TestOneIs(t *testing.T) {
 	is := is.New(t)
 	err := fmt.Errorf("one: %w", fs.ErrNotExist)
-	is.True(errors.Is(errs.Join(nil, err, nil), fs.ErrNotExist))
+	is.True(errors.Is(errs.Join(nil, err, err), fs.ErrNotExist))
+}
+
+// Allow chains of the same error type to continue passing error.Is checks.
+func TestChainIs(t *testing.T) {
+	is := is.New(t)
+	e1 := fmt.Errorf("one: %w", fs.ErrNotExist)
+	e2 := fmt.Errorf("two: %w", e1)
+	is.True(errors.Is(errs.Join(nil, e1, e2), fs.ErrNotExist))
 }
 
 // Can't assume multiple non-nested errors are a certain type of error.


### PR DESCRIPTION
Two minor changes while working on custom views:

- internal/errs: fix error chaining. 
- framework/transform2: remove unused state