### PR TITLE
internal/glob: fix wildcards in multi-select

### DIFF
--- a/internal/glob/compile.go
+++ b/internal/glob/compile.go
@@ -2,7 +2,35 @@ package glob
 
 import "github.com/gobwas/glob"
 
-// Alias for glob.Glob
-var Compile = glob.Compile
-
 type Matcher = glob.Glob
+
+// Comple
+func Compile(pattern string) (Matcher, error) {
+	// Expand patterns like {a,b} into multiple globs a & b. This avoids an
+	// infinite loop described in this comment:
+	// https://github.com/gobwas/glob/issues/50#issuecomment-1330182417
+	patterns, err := Expand(pattern)
+	if err != nil {
+		return nil, err
+	}
+	globs := make(globs, len(patterns))
+	for i, pattern := range patterns {
+		glob, err := glob.Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+		globs[i] = glob
+	}
+	return globs, nil
+}
+
+type globs []glob.Glob
+
+func (globs globs) Match(path string) bool {
+	for _, glob := range globs {
+		if glob.Match(path) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/glob/compile_test.go
+++ b/internal/glob/compile_test.go
@@ -3,7 +3,7 @@ package glob_test
 import (
 	"testing"
 
-	"github.com/gobwas/glob"
+	"github.com/livebud/bud/internal/glob"
 	"github.com/livebud/bud/internal/is"
 )
 
@@ -19,7 +19,15 @@ func TestDirMatch(t *testing.T) {
 	is := is.New(t)
 	matcher, err := glob.Compile("controller/*/**.go")
 	is.NoErr(err)
+	is.True(!matcher.Match("controller"))
 	is.True(!matcher.Match("controller/controller.go"))
 	is.True(matcher.Match("controller/view/view.go"))
 	is.True(matcher.Match("controller/public/public.go"))
+}
+
+func TestMatchSubdir(t *testing.T) {
+	is := is.New(t)
+	matcher, err := glob.Compile(`{generator/**.go,bud/internal/generator/*/**.go}`)
+	is.NoErr(err)
+	is.True(!matcher.Match("bud/internal/generator/generator.go"))
 }


### PR DESCRIPTION
This fixes an issue where a pattern like `{a,b/*/**.go}`, would match on `b/main.go`. Now it won't match on `b/main.go`, but will match on `b/b/main.go` and `b/b/b/main.go`, etc.

More context in this issue: https://github.com/gobwas/glob/issues/50