### PR TITLE
install.sh: remove GITHUB_TOKEN usage in install.sh. Fixes: #348

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -236,11 +236,6 @@ github_api() {
   local_file=$1
   source_url=$2
   header=""
-  case "$source_url" in
-    https://api.github.com*)
-      test -z "$GITHUB_TOKEN" || header="Authorization: token $GITHUB_TOKEN"
-      ;;
-  esac
   http_download "$local_file" "$source_url" "$header"
 }
 github_last_release() {


### PR DESCRIPTION
This PR removes an unnecessary failure mode in the install script. 

Thanks to @chriswalz for reporting this and confirming the fix.