### PR TITLE
move app from bud/internal/app to bud/cmd/app

### DIFF
--- a/contributing/Readme.md
+++ b/contributing/Readme.md
@@ -90,7 +90,7 @@ go run main.go -C hello build
 Sometimes you want to hack on the generated code in `bud/`, but if you run `bud run` any changes you make will be overridden. To avoid this, you can call your app's `main.go` file directly:
 
 ```sh
-go run bud/internal/app/main.go
+go run bud/cmd/app/main.go
 ```
 
 You may encounter an error like this:
@@ -108,7 +108,7 @@ bud tool bs
 This will start a bud server. Next, restart your app server and pass the bud server address in as an environment variable:
 
 ```
-BUD_LISTEN=<bud server address> go run bud/internal/app/main.go
+BUD_LISTEN=<bud server address> go run bud/cmd/app/main.go
 ```
 
 Finally, reload the page and you should be good to go. Happy hacking!

--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -88,7 +88,7 @@ var coreGenerators = []struct {
 }{
 	{
 		Import: "github.com/livebud/bud/framework/app",
-		Path:   "bud/internal/app/main.go",
+		Path:   "bud/cmd/app/main.go",
 		Type:   FileGenerator,
 	},
 	{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -40,7 +40,7 @@ func TestChdir(t *testing.T) {
 	is.Equal(result.Stdout(), "")
 	is.Equal(result.Stderr(), "")
 	is.NoErr(td.Exists(
-		"bud/internal/app",
+		"bud/cmd/app",
 		"bud/app",
 	))
 }
@@ -83,7 +83,7 @@ func TestOutsideModule(t *testing.T) {
 	is.In(result.Stdout(), "  tool")
 	is.In(result.Stdout(), "  version")
 	is.NoErr(td.NotExists(
-		"bud/internal/app",
+		"bud/cmd/app",
 		"bud/app",
 	))
 }
@@ -107,7 +107,7 @@ func TestOutsideModuleHelp(t *testing.T) {
 	is.In(result.Stdout(), "  tool")
 	is.In(result.Stdout(), "  version")
 	is.NoErr(td.NotExists(
-		"bud/internal/app",
+		"bud/cmd/app",
 		"bud/app",
 	))
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -24,7 +24,7 @@ const (
 	afsBinPath  = "bud/afs"
 
 	// cmd/app
-	appMainPath = "bud/internal/app/main.go"
+	appMainPath = "bud/cmd/app/main.go"
 	appBinPath  = "bud/app"
 )
 
@@ -227,8 +227,7 @@ func only(log log.Log, dirs ...string) func(name string, isDir bool) bool {
 func isAFSPath(fpath string) bool {
 	return fpath == afsBinPath ||
 		isWithin(afsGeneratorDir, fpath) ||
-		isWithin(afsMainDir, fpath) ||
-		fpath == "bud/cmd" // TODO: remove once we move app over to cmd/app/main.go
+		isWithin(afsMainDir, fpath)
 }
 
 func isWithin(parent, child string) bool {

--- a/internal/cli/tool_v8_test.go
+++ b/internal/cli/tool_v8_test.go
@@ -23,7 +23,7 @@ func TestToolV8(t *testing.T) {
 	is.Equal(result.Stderr(), "")
 	is.Equal(strings.TrimSpace(result.Stdout()), "4")
 	is.NoErr(td.NotExists(
-		"bud/internal/app",
+		"bud/cmd/app",
 		"bud/app",
 	))
 }


### PR DESCRIPTION
Small cleanup to move the generated app's main.go file from `bud/internal/app/main.go` to `bud/cmd/app/main.go`