### PR TITLE
improve 'bud run' tolerance to errors

### DIFF
--- a/framework/public/public_test.go
+++ b/framework/public/public_test.go
@@ -3,6 +3,7 @@ package public_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/internal/testcli"
@@ -140,7 +141,9 @@ func TestGetChangeGet(t *testing.T) {
 	favicon2 := []byte{0x00, 0x00, 0x01}
 	td.BFiles["public/favicon.ico"] = favicon2
 	is.NoErr(td.Write(ctx))
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	is.NoErr(td.Exists("bud/internal/web/public/public.go"))
 	res, err = app.Get("/favicon.ico")
 	is.NoErr(err)
@@ -169,7 +172,9 @@ func TestEmbedFavicon(t *testing.T) {
 	favicon2 := []byte{0x00, 0x00, 0x01}
 	td.BFiles["public/favicon.ico"] = favicon2
 	is.NoErr(td.Write(ctx))
-	is.NoErr(app.Ready(ctx))
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
 	// Favicon shouldn't have changed
 	res, err = app.Get("/favicon.ico")
 	is.NoErr(err)

--- a/internal/embedded/gitignore.txt
+++ b/internal/embedded/gitignore.txt
@@ -1,2 +1,2 @@
 node_modules
-bud/
+bud

--- a/internal/gitignore/gitignore.go
+++ b/internal/gitignore/gitignore.go
@@ -13,6 +13,9 @@ var alwaysIgnore = []string{
 	"node_modules",
 	".git",
 	".DS_Store",
+	// Regardless of if this directory is committed or not, it should be ignored
+	// because this will trigger unnecessary rebuilds during development.
+	"bud",
 }
 
 var defaultIgnores = append([]string{"/bud"}, alwaysIgnore...)


### PR DESCRIPTION
This PR makes a few changes to make `bud run` more tolerable to errors.

The big one was always ignoring the `bud` directory during `bud run` regardless of if there's a `.gitignore` or not. This alone greatly reduced the number of rebuilds triggered (and likely sped up reloads too!).

I also fixed an issue where if you remove the bud directory entirely during `bud run`, it will now exit more gracefully.

I still think there are ways to end up in weird run states if you're able to kick off multiple generates concurrently. One way to do this would be to have two bud run processes going.

To deal with generates racing, bud's generate should lock to allow only one generate to go at a time. I think we can do this in the `bud/bud.db` SQLite database.