### PR TITLE
framework/generator: updated the custom generator api

### DIFF
--- a/framework/generator/generator.go
+++ b/framework/generator/generator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 
-	"github.com/livebud/bud/internal/bail"
 	"github.com/livebud/bud/internal/gotemplate"
 	"github.com/livebud/bud/internal/imports"
 	"github.com/livebud/bud/package/genfs"
@@ -49,6 +48,6 @@ func (g *Generator) GenerateFile(fsys genfs.FS, file *genfs.File) error {
 
 // Load the generators
 func (g *Generator) Load(fsys fs.FS) (*State, error) {
-	loader := &loader{g.log, g.module, g.parser, imports.New(), bail.Struct{}}
+	loader := &loader{g.log, g.module, g.parser, imports.New()}
 	return loader.Load(fsys)
 }

--- a/framework/generator/generator.gotext
+++ b/framework/generator/generator.gotext
@@ -15,12 +15,30 @@ func New(
 	fsys *genfs.FileSystem,
 	module *gomod.Module,
 	log log.Log,
-	{{- range $generator := $.Generators }}
+	{{- range $generator := $.FileGenerators }}
+	{{ $generator.Camel }} *{{ $generator.Import.Name }}.Generator,
+	{{- end }}
+	{{- range $generator := $.FileServers }}
+	{{ $generator.Camel }} *{{ $generator.Import.Name }}.Generator,
+	{{- end }}
+	{{- range $generator := $.GenerateDirs }}
+	{{ $generator.Camel }} *{{ $generator.Import.Name }}.Generator,
+	{{- end }}
+	{{- range $generator := $.ServeFiles }}
 	{{ $generator.Camel }} *{{ $generator.Import.Name }}.Generator,
 	{{- end }}
 ) FS {
-	{{- range $generator := $.Generators }}
-	fsys.{{ $generator.Type }}(`{{ $generator.Path }}`, {{ $generator.Camel }})
+	{{- range $generator := $.FileGenerators }}
+	fsys.FileGenerator(`{{ $generator.Path }}`, {{ $generator.Camel }})
+	{{- end }}
+	{{- range $generator := $.FileServers }}
+	fsys.FileServer(`{{ $generator.Path }}`, {{ $generator.Camel }})
+	{{- end }}
+	{{- range $generator := $.GenerateDirs }}
+	fsys.GenerateDir(`{{ $generator.Path }}`, {{ $generator.Camel }}.Generate)
+	{{- end }}
+	{{- range $generator := $.ServeFiles }}
+	fsys.ServeFile(`{{ $generator.Path }}`, {{ $generator.Camel }}.Serve)
 	{{- end }}
 	return fsys
 }

--- a/framework/generator/generator.gotext
+++ b/framework/generator/generator.gotext
@@ -35,7 +35,7 @@ func New(
 	fsys.FileServer(`{{ $generator.Path }}`, {{ $generator.Camel }})
 	{{- end }}
 	{{- range $generator := $.GenerateDirs }}
-	fsys.GenerateDir(`{{ $generator.Path }}`, {{ $generator.Camel }}.Generate)
+	fsys.GenerateDir(`{{ $generator.Path }}`, {{ $generator.Camel }}.{{ $generator.Method }})
 	{{- end }}
 	{{- range $generator := $.ServeFiles }}
 	fsys.ServeFile(`{{ $generator.Path }}`, {{ $generator.Camel }}.Serve)

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -24,7 +24,7 @@ func TestGenerators(t *testing.T) {
 			"github.com/livebud/bud/package/genfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			dir.GenerateFile("tailwind.css", func(fsys genfs.FS, file *genfs.File) error {
 				file.Data = []byte("/** tailwind **/")
 				return nil
@@ -58,7 +58,7 @@ func TestGenerators(t *testing.T) {
 		type Generator struct {
 			Markdoc *markdoc.Compiler
 		}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			dir.ServeFile(".", g.compile)
 			dir.GenerateFile("markdoc.go", g.generate)
 			return nil
@@ -70,7 +70,7 @@ func TestGenerators(t *testing.T) {
 			}
 			out := "package markdoc "
 			for _, md := range mds {
-				data, err := fs.ReadFile(fsys, path.Join("bud/generator/markdoc", md))
+				data, err := fs.ReadFile(fsys, path.Join("bud/internal/markdoc", md))
 				if err != nil {
 					return err
 				}
@@ -92,14 +92,14 @@ func TestGenerators(t *testing.T) {
 			return nil
 		}
 	`
-	td.Files["generator/web/viewer/viewer.go"] = `
+	td.Files["generator/frontend/viewer/viewer.go"] = `
 		package viewer
 		import (
 			"github.com/livebud/bud/package/genfs"
 		)
 		type Generator struct {
 		}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			dir.GenerateFile("viewer.go", func(fsys genfs.FS, file *genfs.File) error {
 				file.Data = []byte("package viewer")
 				return nil
@@ -111,26 +111,25 @@ func TestGenerators(t *testing.T) {
 	cli := testcli.New(dir)
 	_, err := cli.Run(ctx, "build", "--embed=false")
 	is.NoErr(err)
-	is.NoErr(td.Exists("bud/generator/tailwind/tailwind.css"))
-	is.NoErr(td.Exists("bud/generator/tailwind/preflight.css"))
-	is.NoErr(td.Exists("bud/generator/markdoc/markdoc.go"))
-	is.NoErr(td.Exists("bud/generator/web/viewer/viewer.go"))
-	data, err := os.ReadFile(td.Path("bud/generator/tailwind/tailwind.css"))
+	is.NoErr(td.Exists("bud/internal/tailwind/tailwind.css"))
+	is.NoErr(td.Exists("bud/internal/tailwind/preflight.css"))
+	is.NoErr(td.Exists("bud/internal/markdoc/markdoc.go"))
+	is.NoErr(td.Exists("bud/internal/frontend/viewer/viewer.go"))
+	data, err := os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
 	is.NoErr(err)
 	is.Equal(string(data), "/** tailwind **/")
-	data, err = os.ReadFile(td.Path("bud/generator/tailwind/preflight.css"))
+	data, err = os.ReadFile(td.Path("bud/internal/tailwind/preflight.css"))
 	is.NoErr(err)
 	is.Equal(string(data), "/** preflight **/")
-	data, err = os.ReadFile(td.Path("bud/generator/markdoc/markdoc.go"))
+	data, err = os.ReadFile(td.Path("bud/internal/markdoc/markdoc.go"))
 	is.NoErr(err)
 	is.Equal(string(data), "package markdoc # About # About # Index # Index ")
-	data, err = os.ReadFile(td.Path("bud/generator/web/viewer/viewer.go"))
+	data, err = os.ReadFile(td.Path("bud/internal/frontend/viewer/viewer.go"))
 	is.NoErr(err)
 	is.Equal(string(data), "package viewer")
 }
 
 func TestMissingGenerator(t *testing.T) {
-	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -146,8 +145,7 @@ func TestMissingGenerator(t *testing.T) {
 	is.NoErr(td.NotExists("bud/command/generate/main"))
 }
 
-func TestMissingGenerateDirMethod(t *testing.T) {
-	t.SkipNow()
+func TestMissingMatchingMethod(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -155,7 +153,7 @@ func TestMissingGenerateDirMethod(t *testing.T) {
 	td.Files["generator/web/transform/transform.go"] = `
 		package transform
 		type Generator struct {}
-		func (g *Generator) Generate() error { return nil }
+		func (g *Generator) generate() error { return nil }
 	`
 	is.NoErr(td.Write(ctx))
 	cli := testcli.New(dir)
@@ -175,7 +173,7 @@ func TestSyntaxError(t *testing.T) {
 			"github.com/livebud/bud/package/genfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			"ok"
 		}
 	`
@@ -189,7 +187,6 @@ func TestSyntaxError(t *testing.T) {
 }
 
 func TestUpdateGenerator(t *testing.T) {
-	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -200,7 +197,7 @@ func TestUpdateGenerator(t *testing.T) {
 			"github.com/livebud/bud/package/genfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			dir.GenerateFile("tailwind.css", func(fsys genfs.FS, file *genfs.File) error {
 				file.Data = []byte("/** tailwind **/")
 				return nil
@@ -214,7 +211,7 @@ func TestUpdateGenerator(t *testing.T) {
 	is.NoErr(err)
 	defer app.Close()
 	// Check for tailwind
-	data, err := os.ReadFile(td.Path("bud/generator/tailwind/tailwind.css"))
+	data, err := os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
 	is.NoErr(err)
 	is.Equal(string(data), "/** tailwind **/")
 	// Update generator
@@ -226,7 +223,7 @@ func TestUpdateGenerator(t *testing.T) {
 		)
 		type Generator struct {
 		}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			dir.GenerateFile("tailwind.css", func(fsys genfs.FS, file *genfs.File) error {
 				file.Data = []byte("/** tailwind2 **/")
 				return nil
@@ -243,17 +240,16 @@ func TestUpdateGenerator(t *testing.T) {
 	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Check for preflight
-	data, err = os.ReadFile(td.Path("bud/generator/tailwind/preflight.css"))
+	data, err = os.ReadFile(td.Path("bud/internal/tailwind/preflight.css"))
 	is.NoErr(err)
 	is.Equal(string(data), "/** preflight **/")
 	// Check that tailwind has been updated
-	data, err = os.ReadFile(td.Path("bud/generator/tailwind/tailwind.css"))
+	data, err = os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
 	is.NoErr(err)
 	is.Equal(string(data), "/** tailwind2 **/")
 }
 
 func TestDeleteGenerator(t *testing.T) {
-	t.SkipNow()
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -264,7 +260,7 @@ func TestDeleteGenerator(t *testing.T) {
 			"github.com/livebud/bud/package/genfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			dir.GenerateFile("tailwind.css", func(fsys genfs.FS, file *genfs.File) error {
 				file.Data = []byte("/** tailwind **/")
 				return nil
@@ -278,7 +274,7 @@ func TestDeleteGenerator(t *testing.T) {
 	is.NoErr(err)
 	defer app.Close()
 	// Check for tailwind
-	data, err := os.ReadFile(td.Path("bud/generator/tailwind/tailwind.css"))
+	data, err := os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
 	is.NoErr(err)
 	is.Equal(string(data), "/** tailwind **/")
 	// Update generator
@@ -289,7 +285,7 @@ func TestDeleteGenerator(t *testing.T) {
 			"github.com/livebud/bud/package/genfs"
 		)
 		type Generator struct {}
-		func (g *Generator) GenerateDir(fsys genfs.FS, dir *genfs.Dir) error {
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
 			return nil
 		}
 	`)), 0644))
@@ -298,7 +294,71 @@ func TestDeleteGenerator(t *testing.T) {
 	is.NoErr(app.Ready(readyCtx))
 	cancel()
 	// Check that tailwind has been updated
-	data, err = os.ReadFile(td.Path("bud/generator/tailwind/tailwind.css"))
+	data, err = os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
 	is.True(os.IsNotExist(err))
 	is.Equal(data, nil)
 }
+
+func TestChangeGenerator(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/genfs"
+		)
+		type Generator struct {}
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
+			dir.GenerateFile("tailwind.css", func(fsys genfs.FS, file *genfs.File) error {
+				file.Data = []byte("/** tailwind **/")
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	app, err := cli.Start(ctx, "run")
+	is.NoErr(err)
+	defer app.Close()
+	// Check for tailwind
+	data, err := os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** tailwind **/")
+	// Update generator
+	generatorFile := filepath.Join(dir, "generator", "tailwind", "tailwind.go")
+	is.NoErr(os.WriteFile(generatorFile, []byte(dedent.Dedent(`
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/genfs"
+		)
+		type Generator struct {}
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
+			dir.GenerateFile("preflight.css", func(fsys genfs.FS, file *genfs.File) error {
+				file.Data = []byte("/** preflight **/")
+				return nil
+			})
+			return nil
+		}
+	`)), 0644))
+	// Wait for the app to be ready again
+	readyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	is.NoErr(app.Ready(readyCtx))
+	cancel()
+	// Check that tailwind has been updated
+	data, err = os.ReadFile(td.Path("bud/internal/tailwind/tailwind.css"))
+	is.True(os.IsNotExist(err))
+	is.Equal(data, nil)
+	// Check for preflight
+	data, err = os.ReadFile(td.Path("bud/internal/tailwind/preflight.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** preflight **/")
+}
+
+// TODO: test for package generators
+// TODO: test for command generators
+// TODO: test for generator servers
+// TODO: test for nested generator generator (e.g. bud/generator/transpile)
+// TODO: test for nested web generators (e.g. bud/generator/web/graphql/routing.go)

--- a/framework/generator/generator_test.go
+++ b/framework/generator/generator_test.go
@@ -357,8 +357,156 @@ func TestChangeGenerator(t *testing.T) {
 	is.Equal(string(data), "/** preflight **/")
 }
 
-// TODO: test for package generators
-// TODO: test for command generators
-// TODO: test for generator servers
-// TODO: test for nested generator generator (e.g. bud/generator/transpile)
-// TODO: test for nested web generators (e.g. bud/generator/web/graphql/routing.go)
+func TestPkgGenerator(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/genfs"
+		)
+		type Generator struct {}
+		func (g *Generator) GeneratePkg(fsys genfs.FS, dir *genfs.Dir) error {
+			dir.GenerateFile("tailwind.css", func(fsys genfs.FS, file *genfs.File) error {
+				file.Data = []byte("/** tailwind **/")
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	res, err := cli.Run(ctx, "build", "--embed=false")
+	is.NoErr(err)
+	is.Equal(res.Stderr(), "")
+	is.Equal(res.Stdout(), "")
+	is.NoErr(td.Exists("bud/pkg/tailwind/tailwind.css"))
+	data, err := os.ReadFile(td.Path("bud/pkg/tailwind/tailwind.css"))
+	is.NoErr(err)
+	is.Equal(string(data), "/** tailwind **/")
+}
+
+func TestCmdGenerator(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/genfs"
+		)
+		type Generator struct {}
+		func (g *Generator) GenerateCmd(fsys genfs.FS, dir *genfs.Dir) error {
+			dir.GenerateFile("main.go", func(fsys genfs.FS, file *genfs.File) error {
+				file.Data = []byte("package main\nfunc main() {}")
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	res, err := cli.Run(ctx, "build", "--embed=false")
+	is.NoErr(err)
+	is.Equal(res.Stderr(), "")
+	is.Equal(res.Stdout(), "")
+	is.NoErr(td.Exists("bud/cmd/tailwind/main.go"))
+	data, err := os.ReadFile(td.Path("bud/cmd/tailwind/main.go"))
+	is.NoErr(err)
+	is.Equal(string(data), "package main\nfunc main() {}")
+}
+
+func TestGeneratorServer(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	td.Files["generator/tailwind/tailwind.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/genfs"
+		)
+		type Generator struct {}
+		func (g *Generator) Serve(fsys genfs.FS, file *genfs.File) error {
+			file.Data = []byte(file.Relative())
+			return nil
+		}
+	`
+	td.Files["generator/view/view.go"] = `
+		package tailwind
+		import (
+			"github.com/livebud/bud/package/genfs"
+			"io/fs"
+		)
+		type Generator struct {}
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
+			dir.GenerateFile("view.go", func(fsys genfs.FS, file *genfs.File) error {
+				code, err := fs.ReadFile(fsys, "bud/internal/tailwind/preflight.css")
+				if err != nil {
+					return err
+				}
+				file.Data = code
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	res, err := cli.Run(ctx, "build", "--embed=false")
+	is.NoErr(err)
+	is.Equal(res.Stderr(), "")
+	is.Equal(res.Stdout(), "")
+	is.NoErr(td.Exists("bud/internal/view/view.go"))
+	data, err := os.ReadFile(td.Path("bud/internal/view/view.go"))
+	is.NoErr(err)
+	is.Equal(string(data), "preflight.css")
+}
+
+// This test is trippy, but amazing. We're testing that we can create a custom
+// generator in $APP/generator/web/health that writes a health.go file to
+// $APP/bud/internal/web/health.go that contains a Handler that the built-in
+// web generator know how to hook up to the web server to expose the /health
+// endpoint.
+func TestCustomWebGenerator(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	td := testdir.New(dir)
+	const healthHandler = `
+		package health
+		import "github.com/livebud/bud/package/router"
+		import "net/http"
+		type Handler struct {}
+		func (h *Handler) Register(r *router.Router) {
+			r.Get("/health", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("all good"))
+			}))
+		}
+	`
+	td.Files["generator/web/health/health.go"] = `
+		package health
+		import "github.com/livebud/bud/package/genfs"
+		type Generator struct {}
+		func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
+			dir.GenerateFile("health.go", func(fsys genfs.FS, file *genfs.File) error {
+				file.Data = []byte(` + "`" + healthHandler + "`" + `)
+				return nil
+			})
+			return nil
+		}
+	`
+	is.NoErr(td.Write(ctx))
+	cli := testcli.New(dir)
+	app, err := cli.Start(ctx, "run")
+	is.NoErr(err)
+	defer app.Close()
+	res, err := app.Get("/health")
+	is.NoErr(err)
+	is.Equal(res.Status(), 200)
+	is.Equal(res.Body().String(), "all good")
+	is.NoErr(app.Close())
+}

--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -94,13 +94,14 @@ func (l *loader) load(fsys fs.FS) (state *State, err error) {
 	for _, generator := range coreFileGenerators {
 		if !exists[generator.Path] {
 			exists[generator.Path] = true
+			name := l.imports.Add(generator.Import)
 			state.FileGenerators = append(state.FileGenerators, &CodeGenerator{
 				Import: &imports.Import{
-					Name: l.imports.Add(generator.Import),
+					Name: name,
 					Path: generator.Import,
 				},
 				Path:  generator.Path,
-				Camel: gotext.Camel(path.Base(generator.Import)),
+				Camel: gotext.Camel(name),
 			})
 		}
 	}
@@ -109,13 +110,14 @@ func (l *loader) load(fsys fs.FS) (state *State, err error) {
 	for _, generator := range coreFileServers {
 		if !exists[generator.Path] {
 			exists[generator.Path] = true
+			name := l.imports.Add(generator.Import)
 			state.FileServers = append(state.FileServers, &CodeGenerator{
 				Import: &imports.Import{
-					Name: l.imports.Add(generator.Import),
+					Name: name,
 					Path: generator.Import,
 				},
 				Path:  generator.Path,
-				Camel: gotext.Camel(path.Base(generator.Import)),
+				Camel: gotext.Camel(name),
 			})
 		}
 	}
@@ -147,13 +149,14 @@ func (l *loader) load(fsys fs.FS) (state *State, err error) {
 			generatorPath := path.Join("bud", "internal", key)
 			if !exists[generatorPath] {
 				exists[generatorPath] = true
+				name := l.imports.Add(importPath)
 				state.GenerateDirs = append(state.GenerateDirs, &CodeGenerator{
 					Import: &imports.Import{
-						Name: l.imports.Add(importPath),
+						Name: name,
 						Path: importPath,
 					},
 					Path:  generatorPath,
-					Camel: gotext.Camel(key),
+					Camel: gotext.Camel(name),
 				})
 			}
 		}
@@ -163,13 +166,14 @@ func (l *loader) load(fsys fs.FS) (state *State, err error) {
 			generatorPath := path.Join("bud", "internal", key)
 			if !exists[generatorPath] {
 				exists[generatorPath] = true
+				name := l.imports.Add(importPath)
 				state.ServeFiles = append(state.ServeFiles, &CodeGenerator{
 					Import: &imports.Import{
-						Name: l.imports.Add(importPath),
+						Name: name,
 						Path: importPath,
 					},
 					Path:  generatorPath,
-					Camel: gotext.Camel(key),
+					Camel: gotext.Camel(name),
 				})
 			}
 		}
@@ -179,13 +183,14 @@ func (l *loader) load(fsys fs.FS) (state *State, err error) {
 			generatorPath := path.Join("bud", "cmd", key)
 			if !exists[generatorPath] {
 				exists[importPath] = true
+				name := l.imports.Add(importPath)
 				state.GenerateDirs = append(state.GenerateDirs, &CodeGenerator{
 					Import: &imports.Import{
-						Name: l.imports.Add(importPath),
+						Name: name,
 						Path: importPath,
 					},
 					Path:  generatorPath,
-					Camel: gotext.Camel(key),
+					Camel: gotext.Camel(name),
 				})
 			}
 		}
@@ -195,13 +200,14 @@ func (l *loader) load(fsys fs.FS) (state *State, err error) {
 			generatorPath := path.Join("bud", "pkg", key)
 			if !exists[generatorPath] {
 				exists[importPath] = true
+				name := l.imports.Add(importPath)
 				state.GenerateDirs = append(state.GenerateDirs, &CodeGenerator{
 					Import: &imports.Import{
-						Name: l.imports.Add(importPath),
+						Name: name,
 						Path: importPath,
 					},
 					Path:  generatorPath,
-					Camel: gotext.Camel(key),
+					Camel: gotext.Camel(name),
 				})
 			}
 		}

--- a/framework/generator/loader.go
+++ b/framework/generator/loader.go
@@ -1,37 +1,210 @@
 package generator
 
 import (
+	"fmt"
 	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/matthewmueller/gotext"
+
 	"github.com/livebud/bud/package/finder"
 	"github.com/livebud/bud/package/log"
 
-	"github.com/livebud/bud/internal/bail"
 	"github.com/livebud/bud/internal/imports"
 	"github.com/livebud/bud/internal/valid"
 	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/parser"
-	"github.com/matthewmueller/gotext"
 )
+
+type coreGenerator struct {
+	Import string
+	Path   string
+}
+
+var coreFileGenerators = []*coreGenerator{
+	{
+		Import: "github.com/livebud/bud/framework/app",
+		Path:   "bud/cmd/app/main.go",
+	},
+	{
+		Import: "github.com/livebud/bud/framework/web",
+		Path:   "bud/internal/web/web.go",
+	},
+	{
+		Import: "github.com/livebud/bud/framework/controller",
+		Path:   "bud/internal/web/controller/controller.go",
+	},
+	{
+		Import: "github.com/livebud/bud/framework/view",
+		Path:   "bud/internal/web/view/view.go",
+	},
+	{
+		Import: "github.com/livebud/bud/framework/public",
+		Path:   "bud/internal/web/public/public.go",
+	},
+	{
+		Import: "github.com/livebud/bud/framework/view/ssr",
+		Path:   "bud/view/_ssr.js",
+	},
+}
+
+var coreFileServers = []*coreGenerator{
+	{
+		Import: "github.com/livebud/bud/framework/view/dom",
+		Path:   "bud/view",
+	},
+	{
+		Import: "github.com/livebud/bud/framework/view/nodemodules",
+		Path:   "bud/node_modules",
+	},
+}
 
 type loader struct {
 	log     log.Log
 	module  *gomod.Module
 	parser  *parser.Parser
 	imports *imports.Set
-	bail.Struct
 }
 
 func (l *loader) Load(fsys fs.FS) (state *State, err error) {
-	defer l.Recover2(&err, "generator")
+	state, err = l.load(fsys)
+	if err != nil {
+		return nil, fmt.Errorf("generator: %w", err)
+	}
+	return state, nil
+}
+
+func (l *loader) load(fsys fs.FS) (state *State, err error) {
 	state = new(State)
-	state.Generators = l.loadGenerators(fsys)
-	state.Generators = append(state.Generators, l.loadCoreGenerators()...)
-	if len(state.Generators) == 0 {
-		return nil, fs.ErrNotExist
+	generatorDirs, err := finder.Find(fsys, "{generator/**.go,bud/internal/generator/*/*.go}", func(path string, isDir bool) (entries []string) {
+		if !isDir && valid.GoFile(path) {
+			entries = append(entries, filepath.Dir(path))
+		}
+		return entries
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	exists := make(map[string]bool)
+
+	// Load the core file generators
+	for _, generator := range coreFileGenerators {
+		if !exists[generator.Path] {
+			exists[generator.Path] = true
+			state.FileGenerators = append(state.FileGenerators, &CodeGenerator{
+				Import: &imports.Import{
+					Name: l.imports.Add(generator.Import),
+					Path: generator.Import,
+				},
+				Path:  generator.Path,
+				Camel: gotext.Camel(path.Base(generator.Import)),
+			})
+		}
+	}
+
+	// Load the core file servers
+	for _, generator := range coreFileServers {
+		if !exists[generator.Path] {
+			exists[generator.Path] = true
+			state.FileServers = append(state.FileServers, &CodeGenerator{
+				Import: &imports.Import{
+					Name: l.imports.Add(generator.Import),
+					Path: generator.Import,
+				},
+				Path:  generator.Path,
+				Camel: gotext.Camel(path.Base(generator.Import)),
+			})
+		}
+	}
+
+	// Load the custom generators
+	for _, generatorDir := range generatorDirs {
+		importPath := l.module.Import(generatorDir)
+
+		// Skip over conflicting generators
+		if exists[importPath] {
+			continue
+		}
+
+		// Parse the generator package
+		pkg, err := l.parser.Parse(generatorDir)
+		if err != nil {
+			return nil, err
+		}
+		// Skip packages that don't have the expected signature
+		generator := pkg.Struct("Generator")
+		if generator == nil {
+			l.log.Debug("framework/generator: skipping package because there's no Generator struct")
+			continue
+		}
+		key := strings.TrimPrefix(generatorDir, "generator/")
+
+		// Support generating directories into the bud/internal directory
+		if generator.Method("Generate") != nil {
+			generatorPath := path.Join("bud", "internal", key)
+			if !exists[generatorPath] {
+				exists[generatorPath] = true
+				state.GenerateDirs = append(state.GenerateDirs, &CodeGenerator{
+					Import: &imports.Import{
+						Name: l.imports.Add(importPath),
+						Path: importPath,
+					},
+					Path:  generatorPath,
+					Camel: gotext.Camel(key),
+				})
+			}
+		}
+
+		// Support serving files from the bud/internal directory
+		if generator.Method("Serve") != nil {
+			generatorPath := path.Join("bud", "internal", key)
+			if !exists[generatorPath] {
+				exists[generatorPath] = true
+				state.ServeFiles = append(state.ServeFiles, &CodeGenerator{
+					Import: &imports.Import{
+						Name: l.imports.Add(importPath),
+						Path: importPath,
+					},
+					Path:  generatorPath,
+					Camel: gotext.Camel(key),
+				})
+			}
+		}
+
+		// Support generating directories into the bud/cmd directory
+		if generator.Method("GenerateCmd") != nil {
+			generatorPath := path.Join("bud", "cmd", key)
+			if !exists[generatorPath] {
+				exists[importPath] = true
+				state.GenerateDirs = append(state.GenerateDirs, &CodeGenerator{
+					Import: &imports.Import{
+						Name: l.imports.Add(importPath),
+						Path: importPath,
+					},
+					Path:  generatorPath,
+					Camel: gotext.Camel(key),
+				})
+			}
+		}
+
+		// Support generating directories into the bud/pkg directory
+		if generator.Method("GeneratePkg") != nil {
+			generatorPath := path.Join("bud", "pkg", key)
+			if !exists[generatorPath] {
+				exists[importPath] = true
+				state.GenerateDirs = append(state.GenerateDirs, &CodeGenerator{
+					Import: &imports.Import{
+						Name: l.imports.Add(importPath),
+						Path: importPath,
+					},
+					Path:  generatorPath,
+					Camel: gotext.Camel(key),
+				})
+			}
+		}
 	}
 	l.imports.AddStd("io/fs")
 	l.imports.AddNamed("genfs", "github.com/livebud/bud/package/genfs")
@@ -39,107 +212,4 @@ func (l *loader) Load(fsys fs.FS) (state *State, err error) {
 	l.imports.AddNamed("log", "github.com/livebud/bud/package/log")
 	state.Imports = l.imports.List()
 	return state, nil
-}
-
-func (l *loader) loadGenerators(fsys fs.FS) (generators []*CodeGenerator) {
-	generatorDirs, err := finder.Find(fsys, "{generator/**.go,bud/internal/generator/*/**.go}", func(path string, isDir bool) (entries []string) {
-		if !isDir && valid.GoFile(path) {
-			entries = append(entries, filepath.Dir(path))
-		}
-		return entries
-	})
-	if err != nil {
-		l.Bail(err)
-	}
-	for _, generatorDir := range generatorDirs {
-		importPath := l.module.Import(generatorDir)
-		pkg, err := l.parser.Parse(generatorDir)
-		if err != nil {
-			l.Bail(err)
-		}
-		// Ensure the package has a Generator and a Register command
-		// matches the accepted signature
-		if s := pkg.Struct("Generator"); s == nil {
-			l.log.Debug("framework/generator: skipping package because there's no Generator struct")
-			continue
-		} else if s.Method("GenerateDir") == nil {
-			l.log.Debug("framework/generator: skipping package because Generator has no Register function")
-			continue
-		}
-		imp := &imports.Import{
-			Name: l.imports.Add(importPath),
-			Path: importPath,
-		}
-		rootlessGenerator := strings.TrimPrefix(generatorDir, "generator/")
-		generators = append(generators, &CodeGenerator{
-			Import: imp,
-			Type:   DirGenerator,
-			Path:   path.Join("bud", "generator", rootlessGenerator),
-			Camel:  gotext.Camel(rootlessGenerator),
-		})
-	}
-	return generators
-}
-
-var coreGenerators = []struct {
-	Import string
-	Path   string
-	Type   Type
-}{
-	{
-		Import: "github.com/livebud/bud/framework/app",
-		Path:   "bud/cmd/app/main.go",
-		Type:   FileGenerator,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/web",
-		Path:   "bud/internal/web/web.go",
-		Type:   FileGenerator,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/controller",
-		Path:   "bud/internal/web/controller/controller.go",
-		Type:   FileGenerator,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/view",
-		Path:   "bud/internal/web/view/view.go",
-		Type:   FileGenerator,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/public",
-		Path:   "bud/internal/web/public/public.go",
-		Type:   FileGenerator,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/view/ssr",
-		Path:   "bud/view/_ssr.js",
-		Type:   FileGenerator,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/view/dom",
-		Path:   "bud/view",
-		Type:   FileServer,
-	},
-	{
-		Import: "github.com/livebud/bud/framework/view/nodemodules",
-		Path:   "bud/node_modules",
-		Type:   FileServer,
-	},
-	// TODO: transform
-}
-
-func (l *loader) loadCoreGenerators() (generators []*CodeGenerator) {
-	for _, generator := range coreGenerators {
-		generators = append(generators, &CodeGenerator{
-			Import: &imports.Import{
-				Name: l.imports.Add(generator.Import),
-				Path: generator.Import,
-			},
-			Path:  generator.Path,
-			Type:  generator.Type,
-			Camel: gotext.Camel(path.Base(generator.Import)),
-		})
-	}
-	return generators
 }

--- a/framework/generator/state.go
+++ b/framework/generator/state.go
@@ -1,6 +1,9 @@
 package generator
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/livebud/bud/internal/imports"
 )
 
@@ -18,4 +21,17 @@ type CodeGenerator struct {
 	Import *imports.Import
 	Path   string // Path that triggers the generator (e.g. "bud/cmd/app/main.go")
 	Camel  string
+}
+
+func (c *CodeGenerator) Method() (string, error) {
+	switch {
+	case strings.HasPrefix(c.Path, "bud/internal"):
+		return "Generate", nil
+	case strings.HasPrefix(c.Path, "bud/cmd"):
+		return "GenerateCmd", nil
+	case strings.HasPrefix(c.Path, "bud/pkg"):
+		return "GeneratePkg", nil
+	default:
+		return "", fmt.Errorf("generator: unexpected generator path %q", c.Path)
+	}
 }

--- a/framework/generator/state.go
+++ b/framework/generator/state.go
@@ -5,21 +5,17 @@ import (
 )
 
 type State struct {
-	Imports    []*imports.Import
-	Generators []*CodeGenerator
+	Imports        []*imports.Import
+	FileGenerators []*CodeGenerator
+	FileServers    []*CodeGenerator
+	GenerateDirs   []*CodeGenerator
+	ServeFiles     []*CodeGenerator
 }
 
 type Type string
 
-const (
-	DirGenerator  Type = "DirGenerator"
-	FileGenerator Type = "FileGenerator"
-	FileServer    Type = "FileServer"
-)
-
 type CodeGenerator struct {
 	Import *imports.Import
-	Type   Type   // Type of generator
 	Path   string // Path that triggers the generator (e.g. "bud/cmd/app/main.go")
 	Camel  string
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -397,6 +397,9 @@ func (c *CLI) listenAFS(listenAFS string) (socket.Listener, error) {
 }
 
 func (c *CLI) listenFileAFS(afsLn socket.Listener) (*os.File, error) {
+	if c.afsFile != nil {
+		return c.afsFile, nil
+	}
 	fileAFS, err := afsLn.File()
 	if err != nil {
 		return nil, err
@@ -455,7 +458,11 @@ func (c *CLI) listenWebFile(webLn socket.Listener) (*os.File, error) {
 
 func (c *CLI) dialAFS(ctx context.Context, afsLn net.Listener) (*remotefs.Client, error) {
 	if c.afsClient != nil {
-		return c.afsClient, nil
+		// For some reason the RPC client needs to be recycled when the RPC server
+		// shuts down.
+		if err := c.afsClient.Close(); err != nil {
+			return nil, err
+		}
 	}
 	afsClient, err := remotefs.Dial(ctx, afsLn.Addr().String())
 	if err != nil {
@@ -478,6 +485,11 @@ func (c *CLI) command(dir string, name string, args ...string) *exec.Cmd {
 
 func (c *CLI) startAFS(ctx context.Context, flag *framework.Flag, module *gomod.Module, afsFile *os.File, devLn net.Listener) (*shell.Process, error) {
 	if c.afsProcess != nil {
+		p, err := c.afsProcess.Restart(ctx)
+		if err != nil {
+			return nil, err
+		}
+		c.afsProcess = p
 		return c.afsProcess, nil
 	}
 	// Initialize the command

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -490,6 +490,7 @@ func (c *CLI) startAFS(ctx context.Context, flag *framework.Flag, module *gomod.
 			return nil, err
 		}
 		c.afsProcess = p
+		c.Closer.Add(c.afsProcess.Close)
 		return c.afsProcess, nil
 	}
 	// Initialize the command

--- a/internal/testcli/testcli.go
+++ b/internal/testcli/testcli.go
@@ -187,7 +187,7 @@ func (c *CLI) Start(ctx context.Context, args ...string) (*Client, error) {
 		webc:   webc,
 		hotc:   budc,
 		// Close function
-		close: func() (err error) {
+		close: func() error {
 			// Cancel the CLI
 			cancel()
 			// Wait for CLI to finish


### PR DESCRIPTION
Hidden in the `v0.2.6` release is custom generator support. I didn't mention it because the API wasn't stable. In this PR, I take another pass over the custom generator API. I'm feeling pretty good about it now.

The important thing to note is that the custom code generators that you'd write for your application are equally as powerful as the code generators that Bud ships with. The benefit of writing custom generators within the framework is that you get caching, depending on other generators and hot reload for free.

For example, if you add the following code in the `$APP/generator/graphql` package:

```go
package graphql

import "github.com/livebud/bud/package/genfs"

type Generator struct {
  // Add dependencies here to load them in via dependency injection
}

func (g *Generator) Generate(fsys genfs.FS, dir *genfs.Dir) error {
  dir.GenerateFile("graphql.go", func(fsys genfs.FS, file *genfs.File) error {
    // Do something custom
    file.Data = []byte(`...`)
    return nil
  })
  return nil
})
```

Then when Bud's generators run, it'll run this custom logic and you'll end up with a `bud/internal/graphql/graphql.go` file.

Remaining Todos:
- [x] Finish writing tests
- [ ] Write docs