### PR TITLE
internal/cli: fix bud create and add a test. fixes: #360

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -165,7 +165,7 @@ func (c *CLI) createGoMod(in *Create, absDir string) (*virtual.File, error) {
 	// Add the required runtime
 	runtime := &createRequire{
 		Import:  "github.com/livebud/bud",
-		Version: versions.Bud,
+		Version: "v" + versions.Bud,
 	}
 	if in.Dev && versions.Bud == "latest" {
 		runtime.Version = "v0.0.0"


### PR DESCRIPTION
Adds the missing `v` prefix that `go.mod` expects.