### PR TITLE
make: fix tests for non-release PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,10 @@ publish:
 	@ echo "Checking for unpushed commits..." && git fetch
 	@ test "" = "`git cherry`" || (echo "Refusing to publish with unpushed commits" && false)
 
+	@ echo "Running sanity tests..."
+	@ go test --ldflags="-s -w -X 'github.com/livebud/bud/internal/versions.Bud=$(BUD_VERSION)'" \
+		./internal/cli/create_test.go -run "TestReleaseVersionOk"
+
 	@ echo "Building binaries into ./release..."
 	@ $(MAKE) --no-print-directory build
 	@ go run scripts/generate-changelog/main.go "v$(BUD_VERSION)" > release/changelog.md

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -194,6 +194,9 @@ func TestCreateRemovePublicGraceful(t *testing.T) {
 }
 
 func TestReleaseVersionOk(t *testing.T) {
+	if versions.Bud == "latest" {
+		t.Skip("Skipping release version test for latest")
+	}
 	is := is.New(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -202,11 +205,6 @@ func TestReleaseVersionOk(t *testing.T) {
 	is.NoErr(err)
 	cli := testcli.New(dir)
 	is.NoErr(td.NotExists(".gitignore"))
-	priorVersion := versions.Bud
-	versions.Bud = "0.2.6"
-	defer func() {
-		versions.Bud = priorVersion
-	}()
 	result, err := cli.Run(ctx, "create", "--dev=false", dir)
 	is.NoErr(err)
 	is.Equal(result.Stdout(), "")
@@ -218,5 +216,5 @@ func TestReleaseVersionOk(t *testing.T) {
 	is.Equal(fileFirstLine(filepath.Join(dir, "go.mod")), "module change.me\n")
 	gomod, err := os.ReadFile(filepath.Join(dir, "go.mod"))
 	is.NoErr(err)
-	is.In(string(gomod), "github.com/livebud/bud v0.2.6")
+	is.In(string(gomod), "github.com/livebud/bud v"+versions.Bud)
 }


### PR DESCRIPTION
This test was added to fix https://github.com/livebud/bud/pull/361, but that's causing failures on non-releases. Now we'll run this test only during the publishing process and skip it every other time.