### PR TITLE
framework/afs: remove unused dep

### DIFF
--- a/framework/afs/afs.go
+++ b/framework/afs/afs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 
-	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/internal/bail"
 	"github.com/livebud/bud/internal/gotemplate"
 	"github.com/livebud/bud/internal/imports"
@@ -24,12 +23,11 @@ func Generate(state *State) ([]byte, error) {
 	return generator.Generate(state)
 }
 
-func New(flag *framework.Flag, injector *di.Injector, log log.Log, module *gomod.Module) *Generator {
-	return &Generator{flag, injector, log, module}
+func New(injector *di.Injector, log log.Log, module *gomod.Module) *Generator {
+	return &Generator{injector, log, module}
 }
 
 type Generator struct {
-	flag     *framework.Flag
 	injector *di.Injector
 	log      log.Log
 	module   *gomod.Module

--- a/framework/transpiler/transpiler.go
+++ b/framework/transpiler/transpiler.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/internal/gotemplate"
 	"github.com/livebud/bud/internal/imports"
 	"github.com/livebud/bud/internal/valid"
@@ -25,12 +24,11 @@ var template string
 var generator = gotemplate.MustParse("framework/transpiler/transpiler.gotext", template)
 
 // New transpiler generator
-func New(flag *framework.Flag, log log.Log, module *gomod.Module, parser *parser.Parser) *Generator {
-	return &Generator{flag, log, module, parser}
+func New(log log.Log, module *gomod.Module, parser *parser.Parser) *Generator {
+	return &Generator{log, module, parser}
 }
 
 type Generator struct {
-	flag   *framework.Flag
 	log    log.Log
 	module *gomod.Module
 	parser *parser.Parser

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -351,9 +351,9 @@ func (c *CLI) genFS(cache genfs.Cache, flag *framework.Flag, log log.Log, module
 	genfs := genfs.New(cache, fsys, log)
 	parser := parser.New(genfs, module)
 	injector := di.New(genfs, log, module, parser)
-	genfs.FileGenerator("bud/internal/generator/transpiler/transpiler.go", transpiler.New(flag, log, module, parser))
+	genfs.FileGenerator("bud/internal/generator/transpiler/transpiler.go", transpiler.New(log, module, parser))
 	genfs.FileGenerator("bud/internal/generator/generator.go", generator.New(log, module, parser))
-	genfs.FileGenerator("bud/cmd/afs/main.go", afs.New(flag, injector, log, module))
+	genfs.FileGenerator("bud/cmd/afs/main.go", afs.New(injector, log, module))
 	return genfs
 }
 


### PR DESCRIPTION
Removes the unused `*framework.Flag` deps in afs.