### PR TITLE
package/{di,parser}: add typespec support

### DIFF
--- a/package/di/finder.go
+++ b/package/di/finder.go
@@ -82,7 +82,7 @@ func (i *Injector) Find(currModule *gomod.Module, dep Dependency) (Declaration, 
 		}).Debug("di: found struct declaration")
 		return decl, nil
 	}
-	// Lastly, look through the type aliases
+	// Look through the type aliases
 	for _, alias := range pkg.Aliases() {
 		decl, err := tryTypeAlias(alias, dep.TypeName())
 		if err != nil {

--- a/package/di/function.go
+++ b/package/di/function.go
@@ -123,9 +123,9 @@ func tryFunction(fn *parser.Function, importPath, dataType string) (*function, e
 		}
 		def, err := param.Definition()
 		if err != nil {
-			importPath, err := parser.ImportPath(pt)
-			if err != nil {
-				return nil, err
+			importPath, err2 := parser.ImportPath(pt)
+			if err2 != nil {
+				return nil, err2
 			}
 			return nil, fmt.Errorf("di: unable to find definition for param %q.%s in %q.%s. %w", importPath, parser.Unqualify(pt).String(), importPath, dataType, err)
 		}
@@ -154,9 +154,9 @@ func tryFunction(fn *parser.Function, importPath, dataType string) (*function, e
 		}
 		def, err := result.Definition()
 		if err != nil {
-			importPath, err := parser.ImportPath(rt)
-			if err != nil {
-				return nil, err
+			importPath, err2 := parser.ImportPath(rt)
+			if err2 != nil {
+				return nil, err2
 			}
 			return nil, fmt.Errorf("di: unable to find definition for result %q.%s in %q.%s. %w", importPath, parser.Unqualify(rt).String(), importPath, dataType, err)
 		}
@@ -186,7 +186,7 @@ type function struct {
 var _ Declaration = (*function)(nil)
 
 func (fn *function) ID() string {
-	return `'` + fn.Import + `'.` + fn.Name
+	return getID(fn.Import, fn.Name)
 }
 
 // Dependencies are the values that the funcDecl depends on to run

--- a/package/parser/alias.go
+++ b/package/parser/alias.go
@@ -6,7 +6,7 @@ import (
 
 type Alias struct {
 	file *File
-	ts   *ast.TypeSpec
+	node *ast.TypeSpec
 	kind Kind // Resolved kind
 }
 
@@ -17,7 +17,7 @@ func (a *Alias) File() *File {
 }
 
 func (a *Alias) Name() string {
-	return a.ts.Name.Name
+	return a.node.Name.Name
 }
 
 func (a *Alias) Kind() Kind {
@@ -26,7 +26,7 @@ func (a *Alias) Kind() Kind {
 
 // Private returns true if the field is private
 func (a *Alias) Private() bool {
-	return isPrivate(a.ts.Name.Name)
+	return isPrivate(a.node.Name.Name)
 }
 
 func (a *Alias) Package() *Package {
@@ -34,7 +34,7 @@ func (a *Alias) Package() *Package {
 }
 
 func (a *Alias) Type() Type {
-	return getType(a, a.ts.Type)
+	return getType(a, a.node.Type)
 }
 
 // Definition goes to the aliases definition

--- a/package/parser/file.go
+++ b/package/parser/file.go
@@ -226,9 +226,38 @@ func (f *File) Aliases() (aliases []*Alias) {
 			}
 			aliases = append(aliases, &Alias{
 				file: f,
-				ts:   ts,
+				node: ts,
 			})
 		}
 	}
 	return aliases
+}
+
+func (f *File) TypeSpec(name string) *TypeSpec {
+	for _, ts := range f.TypeSpecs() {
+		if ts.Name() == name {
+			return ts
+		}
+	}
+	return nil
+}
+
+func (f *File) TypeSpecs() (typeSpecs []*TypeSpec) {
+	for _, decl := range f.node.Decls {
+		node, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range node.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Assign != 0 {
+				continue
+			}
+			typeSpecs = append(typeSpecs, &TypeSpec{
+				file: f,
+				node: ts,
+			})
+		}
+	}
+	return typeSpecs
 }

--- a/package/parser/package.go
+++ b/package/parser/package.go
@@ -111,7 +111,7 @@ func (k Kind) String() string {
 	case 3:
 		return "interface"
 	case 4:
-		return "alias"
+		return "typespec"
 	default:
 		return "unknown"
 	}
@@ -121,6 +121,7 @@ const (
 	KindBuiltin Kind = 1 + iota
 	KindStruct
 	KindInterface
+	KindTypeSpec
 )
 
 // Declaration interface
@@ -226,6 +227,13 @@ func (pkg *Package) Aliases() (aliases []*Alias) {
 		aliases = append(aliases, file.Aliases()...)
 	}
 	return aliases
+}
+
+func (pkg *Package) TypeSpecs() (typeSpecs []*TypeSpec) {
+	for _, file := range pkg.Files() {
+		typeSpecs = append(typeSpecs, file.TypeSpecs()...)
+	}
+	return typeSpecs
 }
 
 // var errIsBuiltin = errors.New("definition is a built-in type")

--- a/package/parser/typespec.go
+++ b/package/parser/typespec.go
@@ -1,0 +1,34 @@
+package parser
+
+import "go/ast"
+
+type TypeSpec struct {
+	file *File
+	node *ast.TypeSpec
+}
+
+var _ Declaration = (*TypeSpec)(nil)
+
+func (t *TypeSpec) Name() string {
+	return t.node.Name.Name
+}
+
+func (t *TypeSpec) Private() bool {
+	return isPrivate(t.Name())
+}
+
+func (t *TypeSpec) File() *File {
+	return t.file
+}
+
+func (t *TypeSpec) Package() *Package {
+	return t.file.Package()
+}
+
+func (t *TypeSpec) Kind() Kind {
+	return KindTypeSpec
+}
+
+func (t *TypeSpec) Type() Type {
+	return getType(t, t.node.Type)
+}


### PR DESCRIPTION
This PR adds support for dependency injection with custom types.  For example, if you wanted to provide `*View` in the following example:

```go
func LoadPages() (Pages, error) {
  return Pages{"index.svelte", "frame.svelte"}, nil
}

type Pages []string

func Load(pages Pages) *View {
  return &View{pages}
}

type View struct {
  pages Pages
}
```

The generated code would look something like:

```go
// Generated. Do not edit
func load() (*View, error) {
  pages, err := LoadPages()
  if err != nil {
    return nil, err
  }
  view := Load(pages)
  return view, nil
}
```

Custom types do not try to initialize themselves (e.g. `Pages{}`). They need to be initialized with a function, so if `LoadPages` 
 wasn't present, `di` would return an error. 

I originally tried passing the empty value through, but it was just too easy for di to succeed, but you didn't actually get the dependency tree you expected.
