### PR TITLE
package/esb: initial esbuild package rewrite

### DIFF
--- a/package/esb/esb.go
+++ b/package/esb/esb.go
@@ -1,0 +1,225 @@
+package esb
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	esbuild "github.com/evanw/esbuild/pkg/api"
+	"github.com/livebud/bud/framework"
+)
+
+// SSR creates a server-rendered preset
+func SSR(flag *framework.Flag, entries ...string) esbuild.BuildOptions {
+
+	options := esbuild.BuildOptions{
+		EntryPoints: entries,
+		Outdir:      "./",
+		Format:      esbuild.FormatIIFE,
+		Platform:    esbuild.PlatformNeutral,
+		GlobalName:  "bud",
+		// Always bundle, use plugins to granularly mark files as external
+		Bundle: true,
+	}
+	// Support minifying
+	if flag.Minify {
+		options.MinifyWhitespace = true
+		options.MinifyIdentifiers = true
+		options.MinifySyntax = true
+	}
+	return options
+}
+
+// DOM creates a browser preset
+func DOM(flag *framework.Flag, entries ...string) esbuild.BuildOptions {
+	options := esbuild.BuildOptions{
+		EntryPoints: entries,
+		Outdir:      "./",
+		Format:      esbuild.FormatESModule,
+		Platform:    esbuild.PlatformBrowser,
+		// Add "import" condition to support svelte/internal
+		// https://esbuild.github.io/api/#how-conditions-work
+		Conditions: []string{"browser", "default", "import"},
+		// Always bundle, use plugins to granularly mark files as external
+		Bundle: true,
+	}
+	// Support minifying
+	if flag.Minify {
+		options.MinifyWhitespace = true
+		options.MinifyIdentifiers = true
+		options.MinifySyntax = true
+	}
+	if flag.Embed {
+		options.Splitting = true
+	}
+	return options
+}
+
+// Serve a single file
+func Serve(fsys fs.FS, options esbuild.BuildOptions) (*esbuild.OutputFile, error) {
+	// Build from a scratch directory to reduce file-system influence
+	tmpdir, err := os.MkdirTemp("", "bud-es-")
+	if err != nil {
+		return nil, fmt.Errorf("es: unable to create scratch dir. %w", err)
+	}
+	options.AbsWorkingDir = tmpdir
+	options.Plugins = append(options.Plugins, virtualPlugin(fsys))
+	// Run esbuild
+	result := esbuild.Build(options)
+	// Check if there were errors
+	if result.Errors != nil {
+		errors := esbuild.FormatMessages(result.Errors, esbuild.FormatMessagesOptions{
+			Kind: esbuild.ErrorMessage,
+		})
+		return nil, fmt.Errorf("es: %s", strings.Join(errors, "\n"))
+	} else if len(result.OutputFiles) == 0 {
+		return nil, fmt.Errorf("es: no output files")
+	}
+	// Return the first file
+	file := result.OutputFiles[0]
+	return &file, nil
+}
+
+// Bundle a group of files
+func Bundle(options esbuild.BuildOptions) ([]esbuild.OutputFile, error) {
+	// Run esbuild
+	result := esbuild.Build(options)
+	// Check if there were errors
+	if result.Errors != nil {
+		errors := esbuild.FormatMessages(result.Errors, esbuild.FormatMessagesOptions{
+			Kind: esbuild.ErrorMessage,
+		})
+		return nil, fmt.Errorf("es: %s", strings.Join(errors, "\n"))
+	}
+	return result.OutputFiles, nil
+}
+
+func resolvePath(fsys fs.FS, fpath string) (string, error) {
+	stat, err := fs.Stat(fsys, fpath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("es: unable to stat %q. %w", fpath, err)
+		}
+		// Read the directory, it might be an extension-less import.
+		// e.g. "react-dom/server" where "react-dom/server.js" exists
+		dir := path.Dir(fpath)
+		des, err := fs.ReadDir(fsys, dir)
+		if err != nil {
+			return "", fmt.Errorf("es: unable to read dir %q. %w", dir, err)
+		}
+		baseAndDot := path.Base(fpath) + "."
+		for _, de := range des {
+			if de.IsDir() {
+				continue
+			}
+			name := de.Name()
+			if !strings.HasPrefix(name, baseAndDot) {
+				continue
+			}
+			switch path.Ext(name) {
+			case ".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".json":
+				fpath = path.Join(dir, name)
+				return fpath, nil
+			}
+		}
+		return "", fmt.Errorf("es: unable to resolve %q. %w", fpath, err)
+	}
+	// Handle reading the index file from a main directory
+	// e.g. "react" resolving to "react/index.js"
+	if stat.IsDir() {
+		des, err := fs.ReadDir(fsys, fpath)
+		if err != nil {
+			return "", fmt.Errorf("es: unable to read dir %q. %w", fpath, err)
+		}
+		for _, de := range des {
+			if de.IsDir() {
+				continue
+			}
+			name := de.Name()
+			if strings.HasPrefix(name, "index.") {
+				switch path.Ext(name) {
+				case ".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".json":
+					fpath = path.Join(fpath, name)
+					return fpath, nil
+				}
+			}
+		}
+		return "", fmt.Errorf("es: unable to resolve %q. %w", fpath, err)
+	}
+	return fpath, nil
+}
+
+func virtualPlugin(fsys fs.FS) esbuild.Plugin {
+	return esbuild.Plugin{
+		Name: "virtual",
+		Setup: func(build esbuild.PluginBuild) {
+			// Resolve relative paths that start with a dot or slash
+			build.OnResolve(esbuild.OnResolveOptions{Filter: `^\.{0,2}/`}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+				fpath := filepath.Clean(args.Path)
+				// Resolve paths relative to the importer
+				if args.Importer != "" {
+					fpath = path.Join(path.Dir(args.Importer), fpath)
+				}
+				resolved, err := resolvePath(fsys, fpath)
+				if err != nil {
+					if errors.Is(err, fs.ErrNotExist) {
+						// Continue to the next resolver
+						return result, nil
+					}
+					return result, err
+				}
+				result.Namespace = "virtual"
+				result.Path = resolved
+				return result, nil
+			})
+			// Resolve node_modules
+			build.OnResolve(esbuild.OnResolveOptions{Filter: `^[@a-z0-9]`}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+				fpath := path.Join("node_modules", args.Path)
+				resolved, err := resolvePath(fsys, fpath)
+				if err != nil {
+					if errors.Is(err, fs.ErrNotExist) {
+						// Continue to the next resolver
+						return result, nil
+					}
+					return result, err
+				}
+				result.Namespace = "virtual"
+				result.Path = resolved
+				return result, nil
+			})
+			// Load virtual files from the virtual filesystem
+			build.OnLoad(esbuild.OnLoadOptions{Filter: ".*", Namespace: "virtual"}, func(args esbuild.OnLoadArgs) (result esbuild.OnLoadResult, err error) {
+				code, err := fs.ReadFile(fsys, args.Path)
+				if err != nil {
+					return result, fmt.Errorf("es: unable to read file %q. %w", args.Path, err)
+				}
+				// Set the loader
+				switch path.Ext(args.Path) {
+				case ".js", ".mjs", ".cjs":
+					result.Loader = esbuild.LoaderJS
+				case ".jsx":
+					result.Loader = esbuild.LoaderJSX
+				case ".ts":
+					result.Loader = esbuild.LoaderTS
+				case ".tsx":
+					result.Loader = esbuild.LoaderTSX
+				case ".json":
+					result.Loader = esbuild.LoaderJSON
+				default:
+					return result, fmt.Errorf("es: unknown loader for %q", args.Path)
+				}
+				// Resolve the directory
+				result.ResolveDir = path.Dir(args.Path)
+				// Set the contents
+				contents := string(code)
+				result.Contents = &contents
+				// Return the result
+				return result, nil
+			})
+		},
+	}
+}

--- a/package/esb/esb_test.go
+++ b/package/esb/esb_test.go
@@ -1,0 +1,50 @@
+package esb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/package/esb"
+	v8 "github.com/livebud/bud/package/js/v8"
+	"github.com/livebud/bud/package/virtual"
+)
+
+func TestServeSSR(t *testing.T) {
+	is := is.New(t)
+	fsys := virtual.Tree{
+		"node_modules/react-dom/server.js": &virtual.File{
+			Data: []byte(`export function renderToString() { return "<h1>hello</h1>" }`),
+		},
+		"node_modules/react/index.js": &virtual.File{
+			Data: []byte(`export function createElement() { return {} }`),
+		},
+		"node_modules/@pkg/slugify/index.mjs": &virtual.File{
+			Data: []byte(`export default function slugify(title) { return title }`),
+		},
+		"view/Header.jsx": &virtual.File{
+			Data: []byte(`export default (props) => <h1>{props.title}</h1>`),
+		},
+		"view/index.jsx": &virtual.File{
+			Data: []byte(`
+				import { renderToString } from 'react-dom/server'
+				import slugify from '@pkg/slugify'
+				import * as React from 'react'
+				import Header from './Header.jsx'
+				export function render (props) {
+					return renderToString(<Header title={slugify(props.title)} />)
+				}
+			`),
+		},
+	}
+	ssr := esb.SSR(&framework.Flag{}, "./view/index.jsx")
+	file, err := esb.Serve(fsys, ssr)
+	is.NoErr(err)
+	vm, err := v8.Load()
+	is.NoErr(err)
+	defer vm.Close()
+	result, err := vm.Eval("view/index.jsx", fmt.Sprintf(`%s; bud.render({ title: "hello" })`, string(file.Contents)))
+	is.NoErr(err)
+	is.Equal(result, `<h1>hello</h1>`)
+}

--- a/package/esb/esb_test.go
+++ b/package/esb/esb_test.go
@@ -50,15 +50,17 @@ func TestServeSSR(t *testing.T) {
 	is.Equal(result, `<h1>hello</h1>`)
 }
 
-// TODO: test tilde ~
-// TODO: test http
 // TODO: Test serve DOM relative entry
 // TODO: Test serve DOM node_module entry (e.g. "./node_modules/react")
-// TODO: Test bundle SSR relative entries
-// TODO: Test bundle DOM relative entries
 // TODO: test resolving different relative path extensions (e.g. ./Header.svelte)
 // TODO: test resolving different node_modules path extensions (e.g. "./node_modules/@ui/Grid.svelte")
-// TODO: test resolving svelte from within an embedded virtual file system
-// TODO: test minifying
-// TODO: test injecting variables
 // TODO: test dependencies of dependencies
+
+// TODO: Test bundle SSR relative entries
+// TODO: Test bundle DOM relative entries
+// TODO: test minifying
+
+// TODO: test tilde ~
+// TODO: test http
+// TODO: test resolving svelte from within an embedded virtual file system
+// TODO: test injecting variables

--- a/package/esb/esb_test.go
+++ b/package/esb/esb_test.go
@@ -2,6 +2,7 @@ package esb_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/livebud/bud/framework"
@@ -39,7 +40,7 @@ func TestServeSSR(t *testing.T) {
 		},
 	}
 	ssr := esb.SSR(&framework.Flag{}, "./view/index.jsx")
-	file, err := esb.Serve(fsys, ssr)
+	file, err := esb.Serve(http.DefaultTransport, fsys, ssr)
 	is.NoErr(err)
 	vm, err := v8.Load()
 	is.NoErr(err)

--- a/package/esb/esb_test.go
+++ b/package/esb/esb_test.go
@@ -49,3 +49,16 @@ func TestServeSSR(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(result, `<h1>hello</h1>`)
 }
+
+// TODO: test tilde ~
+// TODO: test http
+// TODO: Test serve DOM relative entry
+// TODO: Test serve DOM node_module entry (e.g. "./node_modules/react")
+// TODO: Test bundle SSR relative entries
+// TODO: Test bundle DOM relative entries
+// TODO: test resolving different relative path extensions (e.g. ./Header.svelte)
+// TODO: test resolving different node_modules path extensions (e.g. "./node_modules/@ui/Grid.svelte")
+// TODO: test resolving svelte from within an embedded virtual file system
+// TODO: test minifying
+// TODO: test injecting variables
+// TODO: test dependencies of dependencies


### PR DESCRIPTION
This PR adds the `esb` (short for esbuild) package to Bud. The purpose of this package is to provide common presets that viewers can use and extend in #383. 

I'm also taking this opportunity to try and move esbuild fully to a virtual filesystem, so it's much easier to test different combos.