### PR TITLE
Improve log

### DIFF
--- a/framework/afs/afsrt/appfsrt.go
+++ b/framework/afs/afsrt/appfsrt.go
@@ -77,6 +77,6 @@ func listen(log log.Log, path string) (socket.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("afs: serving from %s", ln.Addr())
+	log.Debug("afs: serving from", ln.Addr())
 	return ln, nil
 }

--- a/framework/app/app.gotext
+++ b/framework/app/app.gotext
@@ -96,7 +96,7 @@ func (a *App) Run(ctx context.Context) error {
 	// Inform bud that we're ready
 	budClient.Publish("app:ready", nil)
 	// Start serving requests
-	log.Debug("app: listening on %s", a.Listen)
+	log.Debug("app: listening on", a.Listen)
 	return webServer.Serve(ctx, a.Listen)
 }
 

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -98,7 +98,7 @@ func (c *CLI) Create(ctx context.Context, in *Create) error {
 		if err := os.WriteFile(abspath, file.Data, 0644); err != nil {
 			return err
 		}
-		log.Info("Created: %s", file.Path)
+		log.Info("Created:", file.Path)
 	}
 
 	// Download the dependencies in go.mod to GOMODCACHE
@@ -139,7 +139,7 @@ func (c *CLI) Create(ctx context.Context, in *Create) error {
 	}
 	log.Info("Generated: bud")
 
-	log.Info("Ready: %s", c.Dir)
+	log.Info("Ready:", c.Dir)
 	return nil
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -129,7 +129,7 @@ func (c *CLI) Run(ctx context.Context, in *Run) error {
 			return err
 		}
 		prompter.SuccessReload()
-		log.Debug("restarted the process in %s", time.Since(now))
+		log.Debug("restarted the process in", time.Since(now))
 		appProcess = p
 		return nil
 	}))

--- a/internal/dsync/dsync.go
+++ b/internal/dsync/dsync.go
@@ -153,7 +153,7 @@ func diff(opt *option, sfs fs.FS, sdir string, tfs vfs.ReadWritable, tdir string
 	ops = append(ops, deleteOps...)
 	ops = append(ops, childOps...)
 	for _, op := range ops {
-		log.Debug("op: %s %q", op.Type, op.Path)
+		log.Debug("op:", op.Type, op.Path)
 	}
 	return ops, nil
 }

--- a/package/log/console/console.go
+++ b/package/log/console/console.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-logfmt/logfmt"
 
 	"github.com/livebud/bud/internal/ansi"
-	"github.com/livebud/bud/internal/stacktrace"
 	log "github.com/livebud/bud/package/log"
 )
 
@@ -92,40 +91,27 @@ func (c *console) Log(log *log.Entry) error {
 // Stderr is a console log singleton that writes to stderr
 var stderr = log.New(New(os.Stderr))
 
-// Return a logger with a field
-func Field(key string, value interface{}) log.Log {
-	return stderr.Field(key, value)
-}
-
-// Debug message is written to the console
-func Debug(msg string, args ...interface{}) {
-	stderr.Debug(msg, args...)
-}
-
-// Info message is written to the console
-func Info(msg string, args ...interface{}) {
-	stderr.Info(msg, args...)
-}
-
-// Notice message is written to the console
-func Notice(msg string, args ...interface{}) {
-	stderr.Notice(msg, args...)
-}
-
-// Warn message is written to the console
-func Warn(msg string, args ...interface{}) {
-	stderr.Warn(msg, args...)
-}
-
-// Error message is written to the console
-func Error(msg string, args ...interface{}) {
-	stderr.Error(msg, args...)
-}
-
-// Err message is written to the console
-func Err(err error, msg string, args ...interface{}) {
-	stderr.Fields(log.Fields{
-		"error":  err.Error(),
-		"source": stacktrace.Source(1),
-	}).Error(msg, args...)
-}
+var (
+	// Return a logger with a field
+	Field = stderr.Field
+	// Debug message is written to the console
+	Debug = stderr.Debug
+	// Debugf message is written to the console
+	Debugf = stderr.Debugf
+	// Info message is written to the console
+	Info = stderr.Info
+	// Infof message is written to the console
+	Infof = stderr.Infof
+	// Notice message is written to the console
+	Notice = stderr.Notice
+	// Noticef message is written to the console
+	Noticef = stderr.Noticef
+	// Warn message is written to the console
+	Warn = stderr.Warn
+	// Warnf message is written to the console
+	Warnf = stderr.Warnf
+	// Error message is written to the console
+	Error = stderr.Error
+	// Errorf message is written to the console
+	Errorf = stderr.Errorf
+)

--- a/package/log/console/console_test.go
+++ b/package/log/console/console_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 func TestConsole(t *testing.T) {
-	console.Field("file", "console_test.go").Field("another", "cool story").Debug("hello %s", "mars")
-	console.Field("file", "console_test.go").Field("another", "cool story").Info("hello %s", "mars")
-	console.Field("file", "console_test.go").Field("another", "cool story").Notice("hello %s", "mars")
-	console.Field("file", "console_test.go").Field("another", "cool story").Warn("hello %s", "mars")
-	console.Field("file", "console_test.go").Field("another", "cool story").Error("hello %s", "mars")
-	console.Err(errors.New("one"), "two %s", "three")
+	console.Field("file", "console_test.go").Field("another", "cool story").Debugf("hello %s", "mars")
+	console.Field("file", "console_test.go").Field("another", "cool story").Infof("hello %s", "mars")
+	console.Field("file", "console_test.go").Field("another", "cool story").Noticef("hello %s", "mars")
+	console.Field("file", "console_test.go").Field("another", "cool story").Warnf("hello %s", "mars")
+	console.Field("file", "console_test.go").Field("another", "cool story").Errorf("hello %s", "mars")
+	console.Field("file", "console_test.go").Field("another", "cool story").Error("hello", "mars")
+	console.Error(errors.New("one"), "two", "three")
 	logger := log.New(console.New(os.Stdout))
-	logger.Err(errors.New("one"), "two %s", "three")
+	logger.Error(errors.New("one"), 4, "three")
 }

--- a/package/log/discard.go
+++ b/package/log/discard.go
@@ -14,26 +14,42 @@ func (d discard) Fields(fields map[string]interface{}) Log {
 	return d
 }
 
-func (discard) Debug(msg string, args ...interface{}) error {
+func (discard) Debug(args ...interface{}) error {
 	return nil
 }
 
-func (discard) Info(msg string, args ...interface{}) error {
+func (discard) Debugf(msg string, args ...interface{}) error {
 	return nil
 }
 
-func (discard) Notice(msg string, args ...interface{}) error {
+func (discard) Info(args ...interface{}) error {
 	return nil
 }
 
-func (discard) Warn(msg string, args ...interface{}) error {
+func (discard) Infof(msg string, args ...interface{}) error {
 	return nil
 }
 
-func (discard) Error(msg string, args ...interface{}) error {
+func (discard) Notice(args ...interface{}) error {
 	return nil
 }
 
-func (discard) Err(err error, msg string, args ...interface{}) error {
+func (discard) Noticef(msg string, args ...interface{}) error {
+	return nil
+}
+
+func (discard) Warn(args ...interface{}) error {
+	return nil
+}
+
+func (discard) Warnf(msg string, args ...interface{}) error {
+	return nil
+}
+
+func (discard) Error(args ...interface{}) error {
+	return nil
+}
+
+func (discard) Errorf(msg string, args ...interface{}) error {
 	return nil
 }

--- a/package/log/memory/memory_test.go
+++ b/package/log/memory/memory_test.go
@@ -15,11 +15,11 @@ func TestLog(t *testing.T) {
 	log := log.New(handler)
 	log.Info("hello")
 	log.Info("world")
-	log.Warn("hello %s!", "mars")
+	log.Warnf("hello %s!", "mars")
 	log.Fields(map[string]interface{}{
 		"file":   "memory_test.go",
 		"detail": "file not exist",
-	}).Field("one", "two").Error("%d. oh noz", 1)
+	}).Field("one", "two").Errorf("%d. oh noz", 1)
 	is.Equal(len(handler.Entries), 4)
 	is.Equal(handler.Entries[0].Level.String(), "info")
 	is.Equal(handler.Entries[0].Message, "hello")
@@ -30,28 +30,28 @@ func TestLog(t *testing.T) {
 	is.Equal(handler.Entries[3].Level.String(), "error")
 	is.Equal(handler.Entries[3].Message, "1. oh noz")
 	fields := handler.Entries[3].Fields
-	is.Equal(len(fields), 3)
+	is.Equal(len(fields), 4)
 	is.Equal(fields.Keys()[0], "detail")
 	is.Equal(fields.Get(fields.Keys()[0]), "file not exist")
 	is.Equal(fields.Keys()[1], "file")
 	is.Equal(fields.Get(fields.Keys()[1]), "memory_test.go")
 	is.Equal(fields.Keys()[2], "one")
 	is.Equal(fields.Get(fields.Keys()[2]), "two")
+	is.Equal(fields.Keys()[3], "source")
+	is.In(fields.Get(fields.Keys()[3]), "memory_test.TestLog")
 }
 
 func TestErr(t *testing.T) {
 	is := is.New(t)
 	handler := memory.New()
 	log := log.New(handler)
-	log.Err(errors.New("one"), "two %s", "three")
+	log.Error(errors.New("one"), "two", "three")
 	is.Equal(len(handler.Entries), 1)
 	is.Equal(handler.Entries[0].Level.String(), "error")
-	is.Equal(handler.Entries[0].Message, "two three")
+	is.Equal(handler.Entries[0].Message, "one two three")
 	fields := handler.Entries[0].Fields
-	is.Equal(len(fields), 2)
-	is.Equal(fields.Keys()[0], "error")
-	is.Equal(fields.Get(fields.Keys()[0]), "one")
-	is.Equal(fields.Keys()[1], "source")
-	source := fields.Get(fields.Keys()[1])
-	is.In(source, "memory_test.TestErr:46") // line number may change
+	is.Equal(len(fields), 1)
+	is.Equal(fields.Keys()[0], "source")
+	source := fields.Get(fields.Keys()[0])
+	is.In(source, "memory_test.TestErr") // line number may change
 }


### PR DESCRIPTION
This PR changes the internal logger API to be more familiar:

Before:

- `Info(msg, args ...interface{})` behaved like `fmt.Sprintf` (with a newline)

Now:

- `Info(msg, args ...interface{})` behaves like `fmt.Println`
- `Infof(msg, args ...interface{})` behaves like `fmt.Sprintf` (with a newline)