### PR TITLE
build: add `direnv` support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use asdf

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
-use asdf
+if has asdf; then
+    use asdf
+fi

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,6 +5,11 @@
 # We'll use `asdf` during development to easily test between
 # different versions.
 #
+# We recommend to use `direnv` (https://direnv.net/) alongside with `asdf`
+# to load/unload project-specific environments when changing directories.
+# `asdf-direnv`(https://github.com/asdf-community/asdf-direnv) lets play
+# them together nicely.
+#
 # The versions below are not the only valid versions that Bud supports. To see
 # a more complete list, review the GitHub workflow to see the versions tested
 # in CI.


### PR DESCRIPTION
As [promised](https://github.com/livebud/bud/pull/381#issuecomment-1437730820), this PR adds support for `direnv` to work together with `asdf` seamlessly.

To make use of it, [direnv](https://direnv.net/) and [asdf-direnv](https://github.com/asdf-community/asdf-direnv) should be set up.