### PR TITLE
build: add `direnv` support and integrate with `asdf`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has asdf && has use_asdf; then
+    use asdf
+fi

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,6 +5,15 @@
 # We'll use `asdf` during development to easily test between
 # different versions.
 #
+# We recommend to use `direnv` (https://direnv.net/) alongside with `asdf`
+# to load/unload project-specific environments when changing directories.
+#
+# `asdf-direnv`(https://github.com/asdf-community/asdf-direnv) lets play
+# them together nicely. Please refer to
+# https://github.com/asdf-community/asdf-direnv#setup for instructions on how
+# to set up the integration of both tools to make them work together seamlessly.
+#
+#
 # The versions below are not the only valid versions that Bud supports. To see
 # a more complete list, review the GitHub workflow to see the versions tested
 # in CI.


### PR DESCRIPTION
In reply to the [last PR](https://github.com/livebud/bud/pull/393#issuecomment-1477270170):

> Hmm... just tried it. Getting:
> 
> ```
> direnv: loading ~/dev/src/github.com/livebud/bud/.envrc                                                        
> direnv: using asdf
> /bin/bash:1033: use_asdf: command not found
> ```
> 
> Sorry, I should have been a bit more clear. Basically, I'd like this to support the following matrix:
> 
> * no direnv, no asdf, no problem
> * direnv, no asdf, no problem
> * asdf, no direnv, no problem
> * asdf, direnv, yayyyy
> 
> Reverting for now, but happy to merge once this is sorted.

Oh i c,  `asdf` seemed to be present, but `asdf-direnv` wasn't installed / set  up. So this player should be added to the matrix as well ;)

* no asdf, no direnv, no asdf-direnv, no problem
* asdf, no direnv, no asdf-direnv, no problem
* asdf, direnv, no asdf-direnv, no problem
* asdf, no direnv, asdf-direnv, no problem
* no asdf, direnv, asdf-direnv, no problem
* no asdf, no direnv, asdf-direnv, no problem
* no asdf, direnv, no asdf-direnv, no problem
* asdf, asdf-direnv, direnv hurrayyyy 

Added a check for that one that ensures to have the direnv integration set up correctly for asdf.

(Note: https://github.com/asdf-community/asdf-direnv#setup describes how to set it up. When installed correctly, a util function called `use_asdf()` will be placed inside `~/.config/direnv/lib/use_asdf.sh`.)