### PR TITLE
add ascii -> html rendering. add context to transpiler. add http, import map esbuild plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/keegancsmith/rpc v1.3.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/livebud/bud-test-plugin v0.0.9
-	github.com/livebud/js v0.0.0-20221112072017-b9e63b92aad5
+	github.com/livebud/js v0.0.0-20230416184227-ef633a94787b
 	github.com/livebud/transpiler v0.0.3
 	github.com/matthewmueller/diff v0.0.0-20220104030700-cb2fe910d90c
 	github.com/matthewmueller/gotext v0.0.0-20210424201144-265ed61725ac
@@ -33,7 +33,7 @@ require (
 	github.com/xlab/treeprint v1.1.0
 	go.kuoruan.net/v8go-polyfills v0.5.1-0.20220727011656-c74c5b408ebd
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.1.0
 	golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
 	honnef.co/go/tools v0.3.3
 	rogchap.com/v8go v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59
 	github.com/bep/debounce v1.2.1
+	github.com/buildkite/terminal-to-html v3.2.0+incompatible
 	github.com/cespare/xxhash v1.1.0
 	github.com/evanw/esbuild v0.14.11
 	github.com/fatih/structtag v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/livebud/bud-test-nested-plugin v0.0.5 h1:MpPp20Gng0F+Kvl+L9kttu6nsJIY
 github.com/livebud/bud-test-nested-plugin v0.0.5/go.mod h1:M3QujkGG4ggZ6h75t5zF8MEJFrLTwa2USeIYHQdO2YQ=
 github.com/livebud/bud-test-plugin v0.0.9 h1:JmS4aj+NV52RUroteLs+ld6rcbkBwio7p9qPNutTsqM=
 github.com/livebud/bud-test-plugin v0.0.9/go.mod h1:GTxMZ8W4BIyGIOgAA4hvPHMDDTkaZtfcuhnOcSu3y8M=
-github.com/livebud/js v0.0.0-20221112072017-b9e63b92aad5 h1:7fYJMOnT4WrnjRhJ8B6HiJBGcDVFd9jam0205gn9y1k=
-github.com/livebud/js v0.0.0-20221112072017-b9e63b92aad5/go.mod h1:TDkks+mVAlB96mxcbIAftAxpGteCxoBYGVF1JThjcLk=
 github.com/livebud/js v0.0.0-20230416184227-ef633a94787b h1:blPLG/F7wT8E20kMLPHsWL3hyWSw4M/2a6JgRwFXJPg=
 github.com/livebud/js v0.0.0-20230416184227-ef633a94787b/go.mod h1:Xkuu9hOX5C6DVDx9MLyIqwRC/mT2VfR5KlEJWL/HNOs=
 github.com/livebud/transpiler v0.0.3 h1:OFKPsmfTOywBDoOE/ZFMVjAupk/xVXFlXoAgZNRhh5Q=
@@ -153,8 +151,8 @@ golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 h1:WWB576BN5zNSZc
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
+github.com/buildkite/terminal-to-html v3.2.0+incompatible h1:WdXzl7ZmYzCAz4pElZosPaUlRTW+qwVx/SkQSCa1jXs=
+github.com/buildkite/terminal-to-html v3.2.0+incompatible/go.mod h1:BFFdFecOxCgjdcarqI+8izs6v85CU/1RA/4Bqh4GR7E=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/livebud/bud-test-plugin v0.0.9 h1:JmS4aj+NV52RUroteLs+ld6rcbkBwio7p9q
 github.com/livebud/bud-test-plugin v0.0.9/go.mod h1:GTxMZ8W4BIyGIOgAA4hvPHMDDTkaZtfcuhnOcSu3y8M=
 github.com/livebud/js v0.0.0-20221112072017-b9e63b92aad5 h1:7fYJMOnT4WrnjRhJ8B6HiJBGcDVFd9jam0205gn9y1k=
 github.com/livebud/js v0.0.0-20221112072017-b9e63b92aad5/go.mod h1:TDkks+mVAlB96mxcbIAftAxpGteCxoBYGVF1JThjcLk=
+github.com/livebud/js v0.0.0-20230416184227-ef633a94787b h1:blPLG/F7wT8E20kMLPHsWL3hyWSw4M/2a6JgRwFXJPg=
+github.com/livebud/js v0.0.0-20230416184227-ef633a94787b/go.mod h1:Xkuu9hOX5C6DVDx9MLyIqwRC/mT2VfR5KlEJWL/HNOs=
 github.com/livebud/transpiler v0.0.3 h1:OFKPsmfTOywBDoOE/ZFMVjAupk/xVXFlXoAgZNRhh5Q=
 github.com/livebud/transpiler v0.0.3/go.mod h1:vQYMN//Y2cnM55tw0lOmLGbEETugP7alxTyhQHzNdTI=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
@@ -153,6 +155,7 @@ golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/entrypoint/list.go
+++ b/internal/entrypoint/list.go
@@ -142,7 +142,7 @@ func listViews(fsys fs.FS, tree *tree, dir string) (views []*View, err error) {
 			views = append(views, subviews...)
 			continue
 		}
-		if !valid.ViewEntry(name) {
+		if !valid.View(name) {
 			continue
 		}
 		ext := path.Ext(name)

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -27,6 +27,11 @@ func Join(errs ...error) error {
 	return agg
 }
 
+// Errors is an optional interface that be used to unwrap multiple errors
+type Errors interface {
+	Errors() []error
+}
+
 // Format reverses the error order to make the cause come first
 func Format(err error) string {
 	// Most errors in Bud are joined by a period

--- a/internal/terminal/html.go
+++ b/internal/terminal/html.go
@@ -1,0 +1,25 @@
+package terminal
+
+import (
+	"bytes"
+	_ "embed"
+
+	terminal "github.com/buildkite/terminal-to-html"
+)
+
+// Pre tag
+func Pre(data []byte) []byte {
+	var b bytes.Buffer
+	b.WriteString(`<pre class="term-container">`)
+	b.Write(terminal.Render(data))
+	b.WriteString(`</pre>`)
+	return b.Bytes()
+}
+
+//go:embed terminal.css
+var css []byte
+
+// CSS that needs to be rendered
+func CSS() []byte {
+	return css
+}

--- a/internal/terminal/terminal.css
+++ b/internal/terminal/terminal.css
@@ -1,0 +1,298 @@
+.term-container {
+  background: #171717;
+  border-radius: 5px;
+  color: white;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace;
+  font-size: 12px;
+  line-height: 20px;
+  padding: 14px 18px;
+  white-space: pre-wrap;
+}
+
+.term-container img { max-width: 100%; }
+
+.term a { color: inherit; text-decoration: underline; text-decoration-style: dashed; }
+.term a:hover { color: #2882F9 }
+
+@keyframes blink-animation {
+  to {
+    visibility: hidden;
+  }
+}
+
+.term-fg1 { } /* don't bold beccause it looks weird */
+.term-fg2 { color: #838887; } /* faint (decreased intensity) - same as gray really */
+.term-fg3 { font-style: italic; } /* italic */
+.term-fg4 { text-decoration: underline; } /* underline */
+.term-fg5 { animation: blink-animation 1s steps(3, start) infinite; } /* blink */
+.term-fg9 { text-decoration: line-through; } /* crossed-out */
+
+.term-fg30 { color: #666666; } /* black (but we can't use black, so a diff color) */
+.term-fg31 { color: #ff7070; } /* red */
+.term-fg32 { color: #b0f986; } /* green */
+.term-fg33 { color: #c6c502; } /* yellow */
+.term-fg34 { color: #8db7e0; } /* blue */
+.term-fg35 { color: #f271fb; } /* magenta */
+.term-fg36 { color: #6bf7ff; } /* cyan */
+
+/* high intense colors */
+.term-fgi1 { color: #5ef765; }
+.term-fgi90 { color: #838887; } /* grey */
+.term-fgi91 { color: #ff3333; } /* red */
+.term-fgi92 { color: #00FF00; } /* green */
+.term-fgi93 { color: #fffc67; } /* yellow */
+.term-fgi94 { color: #6871ff; } /* blue */
+.term-fgi95 { color: #ff76ff; } /* magenta */
+.term-fgi96 { color: #60fcff; } /* cyan */
+
+/* background colors */
+.term-bg40 { background: #676767; } /* grey */
+.term-bg41 { background: #ff4343; } /* red */
+.term-bg42 { background: #99ff5f; } /* green */
+
+/* custom foreground/background combos for readability */
+.term-fg31.term-bg40 { color: #F8A39F; }
+
+/* xterm colors */
+.term-fgx16 { color: #000000; }
+.term-fgx17 { color: #00005f; }
+.term-fgx18 { color: #000087; }
+.term-fgx19 { color: #0000af; }
+.term-fgx20 { color: #0000d7; }
+.term-fgx21 { color: #0000ff; }
+.term-fgx22 { color: #005f00; }
+.term-fgx23 { color: #005f5f; }
+.term-fgx24 { color: #005f87; }
+.term-fgx25 { color: #005faf; }
+.term-fgx26 { color: #005fd7; }
+.term-fgx27 { color: #005fff; }
+.term-fgx28 { color: #008700; }
+.term-fgx29 { color: #00875f; }
+.term-fgx30 { color: #008787; }
+.term-fgx31 { color: #0087af; }
+.term-fgx32 { color: #0087d7; }
+.term-fgx33 { color: #0087ff; }
+.term-fgx34 { color: #00af00; }
+.term-fgx35 { color: #00af5f; }
+.term-fgx36 { color: #00af87; }
+.term-fgx37 { color: #00afaf; }
+.term-fgx38 { color: #00afd7; }
+.term-fgx39 { color: #00afff; }
+.term-fgx40 { color: #00d700; }
+.term-fgx41 { color: #00d75f; }
+.term-fgx42 { color: #00d787; }
+.term-fgx43 { color: #00d7af; }
+.term-fgx44 { color: #00d7d7; }
+.term-fgx45 { color: #00d7ff; }
+.term-fgx46 { color: #00ff00; }
+.term-fgx47 { color: #00ff5f; }
+.term-fgx48 { color: #00ff87; }
+.term-fgx49 { color: #00ffaf; }
+.term-fgx50 { color: #00ffd7; }
+.term-fgx51 { color: #00ffff; }
+.term-fgx52 { color: #5f0000; }
+.term-fgx53 { color: #5f005f; }
+.term-fgx54 { color: #5f0087; }
+.term-fgx55 { color: #5f00af; }
+.term-fgx56 { color: #5f00d7; }
+.term-fgx57 { color: #5f00ff; }
+.term-fgx58 { color: #5f5f00; }
+.term-fgx59 { color: #5f5f5f; }
+.term-fgx60 { color: #5f5f87; }
+.term-fgx61 { color: #5f5faf; }
+.term-fgx62 { color: #5f5fd7; }
+.term-fgx63 { color: #5f5fff; }
+.term-fgx64 { color: #5f8700; }
+.term-fgx65 { color: #5f875f; }
+.term-fgx66 { color: #5f8787; }
+.term-fgx67 { color: #5f87af; }
+.term-fgx68 { color: #5f87d7; }
+.term-fgx69 { color: #5f87ff; }
+.term-fgx70 { color: #5faf00; }
+.term-fgx71 { color: #5faf5f; }
+.term-fgx72 { color: #5faf87; }
+.term-fgx73 { color: #5fafaf; }
+.term-fgx74 { color: #5fafd7; }
+.term-fgx75 { color: #5fafff; }
+.term-fgx76 { color: #5fd700; }
+.term-fgx77 { color: #5fd75f; }
+.term-fgx78 { color: #5fd787; }
+.term-fgx79 { color: #5fd7af; }
+.term-fgx80 { color: #5fd7d7; }
+.term-fgx81 { color: #5fd7ff; }
+.term-fgx82 { color: #5fff00; }
+.term-fgx83 { color: #5fff5f; }
+.term-fgx84 { color: #5fff87; }
+.term-fgx85 { color: #5fffaf; }
+.term-fgx86 { color: #5fffd7; }
+.term-fgx87 { color: #5fffff; }
+.term-fgx88 { color: #870000; }
+.term-fgx89 { color: #87005f; }
+.term-fgx90 { color: #870087; }
+.term-fgx91 { color: #8700af; }
+.term-fgx92 { color: #8700d7; }
+.term-fgx93 { color: #8700ff; }
+.term-fgx94 { color: #875f00; }
+.term-fgx95 { color: #875f5f; }
+.term-fgx96 { color: #875f87; }
+.term-fgx97 { color: #875faf; }
+.term-fgx98 { color: #875fd7; }
+.term-fgx99 { color: #875fff; }
+.term-fgx100 { color: #878700; }
+.term-fgx101 { color: #87875f; }
+.term-fgx102 { color: #878787; }
+.term-fgx103 { color: #8787af; }
+.term-fgx104 { color: #8787d7; }
+.term-fgx105 { color: #8787ff; }
+.term-fgx106 { color: #87af00; }
+.term-fgx107 { color: #87af5f; }
+.term-fgx108 { color: #87af87; }
+.term-fgx109 { color: #87afaf; }
+.term-fgx110 { color: #87afd7; }
+.term-fgx111 { color: #87afff; }
+.term-fgx112 { color: #87d700; }
+.term-fgx113 { color: #87d75f; }
+.term-fgx114 { color: #87d787; }
+.term-fgx115 { color: #87d7af; }
+.term-fgx116 { color: #87d7d7; }
+.term-fgx117 { color: #87d7ff; }
+.term-fgx118 { color: #87ff00; }
+.term-fgx119 { color: #87ff5f; }
+.term-fgx120 { color: #87ff87; }
+.term-fgx121 { color: #87ffaf; }
+.term-fgx122 { color: #87ffd7; }
+.term-fgx123 { color: #87ffff; }
+.term-fgx124 { color: #af0000; }
+.term-fgx125 { color: #af005f; }
+.term-fgx126 { color: #af0087; }
+.term-fgx127 { color: #af00af; }
+.term-fgx128 { color: #af00d7; }
+.term-fgx129 { color: #af00ff; }
+.term-fgx130 { color: #af5f00; }
+.term-fgx131 { color: #af5f5f; }
+.term-fgx132 { color: #af5f87; }
+.term-fgx133 { color: #af5faf; }
+.term-fgx134 { color: #af5fd7; }
+.term-fgx135 { color: #af5fff; }
+.term-fgx136 { color: #af8700; }
+.term-fgx137 { color: #af875f; }
+.term-fgx138 { color: #af8787; }
+.term-fgx139 { color: #af87af; }
+.term-fgx140 { color: #af87d7; }
+.term-fgx141 { color: #af87ff; }
+.term-fgx142 { color: #afaf00; }
+.term-fgx143 { color: #afaf5f; }
+.term-fgx144 { color: #afaf87; }
+.term-fgx145 { color: #afafaf; }
+.term-fgx146 { color: #afafd7; }
+.term-fgx147 { color: #afafff; }
+.term-fgx148 { color: #afd700; }
+.term-fgx149 { color: #afd75f; }
+.term-fgx150 { color: #afd787; }
+.term-fgx151 { color: #afd7af; }
+.term-fgx152 { color: #afd7d7; }
+.term-fgx153 { color: #afd7ff; }
+.term-fgx154 { color: #afff00; }
+.term-fgx155 { color: #afff5f; }
+.term-fgx156 { color: #afff87; }
+.term-fgx157 { color: #afffaf; }
+.term-fgx158 { color: #afffd7; }
+.term-fgx159 { color: #afffff; }
+.term-fgx160 { color: #d70000; }
+.term-fgx161 { color: #d7005f; }
+.term-fgx162 { color: #d70087; }
+.term-fgx163 { color: #d700af; }
+.term-fgx164 { color: #d700d7; }
+.term-fgx165 { color: #d700ff; }
+.term-fgx166 { color: #d75f00; }
+.term-fgx167 { color: #d75f5f; }
+.term-fgx168 { color: #d75f87; }
+.term-fgx169 { color: #d75faf; }
+.term-fgx170 { color: #d75fd7; }
+.term-fgx171 { color: #d75fff; }
+.term-fgx172 { color: #d78700; }
+.term-fgx173 { color: #d7875f; }
+.term-fgx174 { color: #d78787; }
+.term-fgx175 { color: #d787af; }
+.term-fgx176 { color: #d787d7; }
+.term-fgx177 { color: #d787ff; }
+.term-fgx178 { color: #d7af00; }
+.term-fgx179 { color: #d7af5f; }
+.term-fgx180 { color: #d7af87; }
+.term-fgx181 { color: #d7afaf; }
+.term-fgx182 { color: #d7afd7; }
+.term-fgx183 { color: #d7afff; }
+.term-fgx184 { color: #d7d700; }
+.term-fgx185 { color: #d7d75f; }
+.term-fgx186 { color: #d7d787; }
+.term-fgx187 { color: #d7d7af; }
+.term-fgx188 { color: #d7d7d7; }
+.term-fgx189 { color: #d7d7ff; }
+.term-fgx190 { color: #d7ff00; }
+.term-fgx191 { color: #d7ff5f; }
+.term-fgx192 { color: #d7ff87; }
+.term-fgx193 { color: #d7ffaf; }
+.term-fgx194 { color: #d7ffd7; }
+.term-fgx195 { color: #d7ffff; }
+.term-fgx196 { color: #ff0000; }
+.term-fgx197 { color: #ff005f; }
+.term-fgx198 { color: #ff0087; }
+.term-fgx199 { color: #ff00af; }
+.term-fgx200 { color: #ff00d7; }
+.term-fgx201 { color: #ff00ff; }
+.term-fgx202 { color: #ff5f00; }
+.term-fgx203 { color: #ff5f5f; }
+.term-fgx204 { color: #ff5f87; }
+.term-fgx205 { color: #ff5faf; }
+.term-fgx206 { color: #ff5fd7; }
+.term-fgx207 { color: #ff5fff; }
+.term-fgx208 { color: #ff8700; }
+.term-fgx209 { color: #ff875f; }
+.term-fgx210 { color: #ff8787; }
+.term-fgx211 { color: #ff87af; }
+.term-fgx212 { color: #ff87d7; }
+.term-fgx213 { color: #ff87ff; }
+.term-fgx214 { color: #ffaf00; }
+.term-fgx215 { color: #ffaf5f; }
+.term-fgx216 { color: #ffaf87; }
+.term-fgx217 { color: #ffafaf; }
+.term-fgx218 { color: #ffafd7; }
+.term-fgx219 { color: #ffafff; }
+.term-fgx220 { color: #ffd700; }
+.term-fgx221 { color: #ffd75f; }
+.term-fgx222 { color: #ffd787; }
+.term-fgx223 { color: #ffd7af; }
+.term-fgx224 { color: #ffd7d7; }
+.term-fgx225 { color: #ffd7ff; }
+.term-fgx226 { color: #ffff00; }
+.term-fgx227 { color: #ffff5f; }
+.term-fgx228 { color: #ffff87; }
+.term-fgx229 { color: #ffffaf; }
+.term-fgx230 { color: #ffffd7; }
+.term-fgx231 { color: #ffffff; }
+.term-fgx232 { color: #080808; }
+.term-fgx233 { color: #121212; }
+.term-fgx234 { color: #1c1c1c; }
+.term-fgx235 { color: #262626; }
+.term-fgx236 { color: #303030; }
+.term-fgx237 { color: #3a3a3a; }
+.term-fgx238 { color: #444444; }
+.term-fgx239 { color: #4e4e4e; }
+.term-fgx240 { color: #585858; }
+.term-fgx241 { color: #626262; }
+.term-fgx242 { color: #6c6c6c; }
+.term-fgx243 { color: #767676; }
+.term-fgx244 { color: #808080; }
+.term-fgx245 { color: #8a8a8a; }
+.term-fgx246 { color: #949494; }
+.term-fgx247 { color: #9e9e9e; }
+.term-fgx248 { color: #a8a8a8; }
+.term-fgx249 { color: #b2b2b2; }
+.term-fgx250 { color: #bcbcbc; }
+.term-fgx251 { color: #c6c6c6; }
+.term-fgx252 { color: #d0d0d0; }
+.term-fgx253 { color: #dadada; }
+.term-fgx254 { color: #e4e4e4; }
+.term-fgx255 { color: #eeeeee; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "bud",
       "devDependencies": {
         "@types/jsesc": "3.0.1",
         "@types/react": "18.0.0",

--- a/package/es/bundle_test.go
+++ b/package/es/bundle_test.go
@@ -2,13 +2,11 @@ package es_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/package/es"
-	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/log/testlog"
 	"github.com/livebud/bud/package/testdir"
 )
@@ -55,10 +53,9 @@ func TestBundleSSR(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	files, err := esb.Bundle(&es.Bundle{
+		AbsDir:   td.Directory(),
 		Entries:  []string{"./view/index.jsx", "./view/show.jsx"},
 		Platform: es.SSR,
 	})
@@ -67,8 +64,8 @@ func TestBundleSSR(t *testing.T) {
 	// TODO: figure out a better test
 	// SSR would typically be just one big file anyway
 	// DOM is where you chunk the files
-	fmt.Println(string(files[0].Contents))
-	fmt.Println(string(files[1].Contents))
+	// fmt.Println(string(files[0].Contents))
+	// fmt.Println(string(files[1].Contents))
 
 	// vm, err := v8.Load()
 	// is.NoErr(err)

--- a/package/es/es.go
+++ b/package/es/es.go
@@ -2,12 +2,10 @@ package es
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	esbuild "github.com/evanw/esbuild/pkg/api"
 	"github.com/livebud/bud/framework"
-	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/log"
 )
 
@@ -16,13 +14,13 @@ type Builder interface {
 	Bundle(bundle *Bundle) ([]File, error)
 }
 
-func New(flag *framework.Flag, log log.Log, module *gomod.Module) Builder {
-	return &builder{flag, module}
+func New(flag *framework.Flag, log log.Log) Builder {
+	return &builder{flag, log}
 }
 
 type builder struct {
-	flag   *framework.Flag
-	module *gomod.Module
+	flag *framework.Flag
+	log  log.Log
 }
 
 var _ Builder = (*builder)(nil)
@@ -38,6 +36,7 @@ const (
 )
 
 type Serve struct {
+	AbsDir   string
 	Entry    string
 	Plugins  []esbuild.Plugin
 	Platform Platform
@@ -46,9 +45,9 @@ type Serve struct {
 func (b *builder) serveOptions(serve *Serve) esbuild.BuildOptions {
 	switch serve.Platform {
 	case DOM:
-		return b.dom([]string{serve.Entry}, serve.Plugins)
+		return b.dom(serve.AbsDir, []string{serve.Entry}, serve.Plugins)
 	default:
-		return b.ssr([]string{serve.Entry}, serve.Plugins)
+		return b.ssr(serve.AbsDir, []string{serve.Entry}, serve.Plugins)
 	}
 }
 
@@ -58,15 +57,12 @@ func (b *builder) Serve(serve *Serve) (*File, error) {
 	if !isRelativeEntry(serve.Entry) {
 		return nil, fmt.Errorf("%w %q", ErrNotRelative, serve.Entry)
 	}
-	// Externalize dependencies in development on non-dependency entries
-	if serve.Platform == DOM && !b.flag.Embed && !isNodeModuleEntry(serve.Entry) {
-		serve.Plugins = append(serve.Plugins, domExternalize())
-	}
 	result := esbuild.Build(b.serveOptions(serve))
 	// Check if there were errors
 	if result.Errors != nil {
 		errors := esbuild.FormatMessages(result.Errors, esbuild.FormatMessagesOptions{
-			Kind: esbuild.ErrorMessage,
+			Kind:  esbuild.ErrorMessage,
+			Color: true,
 		})
 		return nil, fmt.Errorf("es: %s", strings.Join(errors, "\n"))
 	} else if len(result.OutputFiles) == 0 {
@@ -78,6 +74,7 @@ func (b *builder) Serve(serve *Serve) (*File, error) {
 }
 
 type Bundle struct {
+	AbsDir   string
 	Entries  []string
 	Plugins  []esbuild.Plugin
 	Platform Platform
@@ -86,9 +83,9 @@ type Bundle struct {
 func (b *builder) bundleOptions(bundle *Bundle) esbuild.BuildOptions {
 	switch bundle.Platform {
 	case DOM:
-		return b.dom(bundle.Entries, bundle.Plugins)
+		return b.dom(bundle.AbsDir, bundle.Entries, bundle.Plugins)
 	default:
-		return b.ssr(bundle.Entries, bundle.Plugins)
+		return b.ssr(bundle.AbsDir, bundle.Entries, bundle.Plugins)
 	}
 }
 
@@ -102,7 +99,8 @@ func (b *builder) Bundle(bundle *Bundle) ([]File, error) {
 	// Check if there were errors
 	if result.Errors != nil {
 		errors := esbuild.FormatMessages(result.Errors, esbuild.FormatMessagesOptions{
-			Kind: esbuild.ErrorMessage,
+			Kind:  esbuild.ErrorMessage,
+			Color: true,
 		})
 		return nil, fmt.Errorf("es: %s", strings.Join(errors, "\n"))
 	} else if len(result.OutputFiles) == 0 {
@@ -116,11 +114,11 @@ const outDir = "./"
 const globalName = "bud"
 
 // SSR creates a server-rendered preset
-func (b *builder) ssr(entries []string, plugins []esbuild.Plugin) esbuild.BuildOptions {
+func (b *builder) ssr(absDir string, entries []string, plugins []esbuild.Plugin) esbuild.BuildOptions {
 	options := esbuild.BuildOptions{
 		EntryPoints:   entries,
 		Plugins:       plugins,
-		AbsWorkingDir: b.module.Directory(),
+		AbsWorkingDir: absDir,
 		Outdir:        outDir,
 		Format:        esbuild.FormatIIFE,
 		Platform:      esbuild.PlatformNeutral,
@@ -137,11 +135,11 @@ func (b *builder) ssr(entries []string, plugins []esbuild.Plugin) esbuild.BuildO
 }
 
 // DOM creates a dom-rendered preset
-func (b *builder) dom(entries []string, plugins []esbuild.Plugin) esbuild.BuildOptions {
+func (b *builder) dom(absDir string, entries []string, plugins []esbuild.Plugin) esbuild.BuildOptions {
 	options := esbuild.BuildOptions{
 		EntryPoints:   entries,
 		Plugins:       plugins,
-		AbsWorkingDir: b.module.Directory(),
+		AbsWorkingDir: absDir,
 		Outdir:        outDir,
 		Format:        esbuild.FormatESModule,
 		Platform:      esbuild.PlatformBrowser,
@@ -163,44 +161,6 @@ func (b *builder) dom(entries []string, plugins []esbuild.Plugin) esbuild.BuildO
 	return options
 }
 
-func domExternalize() esbuild.Plugin {
-	return esbuild.Plugin{
-		Name: "dom_external_modules",
-		Setup: func(epb esbuild.PluginBuild) {
-			epb.OnResolve(esbuild.OnResolveOptions{Filter: ".*"}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
-				// Externalize node modules
-				if args.Importer != "" && isNodeModule(args.Path) {
-					result.Path = "/" + path.Join("node_modules", args.Path)
-					result.External = true
-					return result, nil
-				}
-				// Don't externalize the entry file or any local files
-				return result, nil
-			})
-		},
-	}
-}
-
-func isNodeModuleEntry(importPath string) bool {
-	importPath = path.Clean(importPath)
-	if len(importPath) == 0 {
-		return false
-	}
-	if importPath[0] == '/' {
-		return strings.HasPrefix(importPath, "/node_modules/")
-	}
-	return strings.HasPrefix(importPath, "node_modules/")
-}
-
 func isRelativeEntry(entry string) bool {
 	return strings.HasPrefix(entry, "./")
-}
-
-func isNodeModule(path string) bool {
-	switch path[0] {
-	case '.', '/', '\\':
-		return false
-	default:
-		return true
-	}
 }

--- a/package/es/http.go
+++ b/package/es/http.go
@@ -1,0 +1,88 @@
+package es
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	esbuild "github.com/evanw/esbuild/pkg/api"
+)
+
+const httpNamespace = "http-url"
+
+func ExternalHTTP() esbuild.Plugin {
+	return esbuild.Plugin{
+		Name: "http",
+		Setup: func(build esbuild.PluginBuild) {
+			// Externalize any HTTP URLs
+			build.OnResolve(esbuild.OnResolveOptions{Filter: `^https?://`}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+				result.Path = args.Path
+				result.External = true
+				return result, nil
+			})
+		},
+	}
+}
+
+func HTTP(client *http.Client) esbuild.Plugin {
+	return esbuild.Plugin{
+		Name: "http",
+		Setup: func(build esbuild.PluginBuild) {
+			// Intercept import paths starting with "http:" and "https:" so esbuild
+			// doesn't attempt to map them to a file system location. Tag them with
+			// the "http-url" namespace to associate them with this plugin.
+			build.OnResolve(esbuild.OnResolveOptions{Filter: `^https?://`}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+				result.Path = args.Path
+				result.Namespace = httpNamespace
+				return result, nil
+			})
+
+			// We also want to intercept all import paths inside downloaded files and
+			// resolve them against the original URL. All of these files will be in
+			// the "http-url" namespace. Make sure to keep the newly resolved URL in
+			// the "http-url" namespace so imports inside it will also be resolved as
+			// URLs recursively.
+			build.OnResolve(esbuild.OnResolveOptions{Filter: ".*", Namespace: httpNamespace}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+				importer, ok := args.PluginData.(string)
+				if !ok {
+					return result, fmt.Errorf("expected plugin data for %q to be a string but got %v", args.Path, args.PluginData)
+				}
+				base, err := url.Parse(importer)
+				if err != nil {
+					return result, err
+				}
+				relative, err := url.Parse(args.Path)
+				if err != nil {
+					return result, err
+				}
+				result.Path = base.ResolveReference(relative).String()
+				result.Namespace = httpNamespace
+				return result, nil
+			})
+
+			// When a URL is loaded, we want to actually download the content from the
+			// internet. We use plugin data to pass the final URL (after redirects)
+			// back to the future resolvers.
+			build.OnLoad(esbuild.OnLoadOptions{Filter: ".*", Namespace: httpNamespace}, func(args esbuild.OnLoadArgs) (result esbuild.OnLoadResult, err error) {
+				res, err := client.Get(args.Path)
+				if err != nil {
+					return result, err
+				}
+				defer res.Body.Close()
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					return result, err
+				}
+				if res.StatusCode != 200 {
+					return result, fmt.Errorf("unexpected response for GET %q: %s. %s", args.Path, res.Status, string(body))
+				}
+				contents := string(body)
+				result.Contents = &contents
+				result.ResolveDir = "/" + res.Request.URL.String()
+				result.PluginData = res.Request.URL.String()
+				return result, nil
+			})
+		},
+	}
+}

--- a/package/es/http_test.go
+++ b/package/es/http_test.go
@@ -1,0 +1,69 @@
+package es_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/package/es"
+	"github.com/livebud/bud/package/log/testlog"
+	"github.com/livebud/bud/package/testdir"
+)
+
+func TestHTTP(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	log := testlog.New()
+	td, err := testdir.Load()
+	is.NoErr(err)
+	td.Files["view/index.js"] = `
+		import { uid } from 'https://esm.run/uid'
+		export function createElement() { return uid() }
+	`
+	is.NoErr(td.Write(ctx))
+	flag := &framework.Flag{}
+	esb := es.New(flag, log)
+	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
+		Entry:    "./view/index.js",
+		Platform: es.DOM,
+		Plugins: []es.Plugin{
+			es.HTTP(http.DefaultClient),
+		},
+	})
+	is.NoErr(err)
+	code := string(file.Contents)
+	is.In(code, "function createElement() {")
+	is.In(code, "(t + 256).toString(16).substring(1)")
+	is.In(code, "Math.random()")
+}
+
+func TestHTTPDepOfDep(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	log := testlog.New()
+	td, err := testdir.Load()
+	is.NoErr(err)
+	td.Files["view/index.js"] = `
+		import { uid } from 'https://esm.run/uid/secure'
+		export function createElement() { return uid() }
+	`
+	is.NoErr(td.Write(ctx))
+	flag := &framework.Flag{}
+	esb := es.New(flag, log)
+	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
+		Entry:    "./view/index.js",
+		Platform: es.SSR,
+		Plugins: []es.Plugin{
+			es.HTTP(http.DefaultClient),
+		},
+	})
+	is.NoErr(err)
+	code := string(file.Contents)
+	is.In(code, "function createElement() {")
+	is.In(code, "(n + 256).toString(16).substring(1)")
+	is.In(code, "crypto.getRandomValues")
+}

--- a/package/es/importmap.go
+++ b/package/es/importmap.go
@@ -1,0 +1,53 @@
+package es
+
+import (
+	"regexp"
+
+	esbuild "github.com/evanw/esbuild/pkg/api"
+	"github.com/livebud/bud/package/log"
+)
+
+// ImportMap rewrites imports to a different path. If the import path is a URL,
+// you'll need to also add the HTTP plugin.
+// TODO: turn into a single `OnResolve` function
+func ImportMap(log log.Log, imports map[string]string) esbuild.Plugin {
+	return importMap(log, imports, false)
+}
+
+// ExternalImportMap rewrites imports to a different path and marks them as external
+func ExternalImportMap(log log.Log, imports map[string]string) esbuild.Plugin {
+	return importMap(log, imports, true)
+}
+
+func importMap(log log.Log, imports map[string]string, external bool) esbuild.Plugin {
+	return esbuild.Plugin{
+		Name: "import_map",
+		Setup: func(epb esbuild.PluginBuild) {
+			for from, to := range imports {
+				from, to := from, to
+				reFrom := regexp.QuoteMeta(from)
+				if from[len(from)-1] == '/' {
+					epb.OnResolve(esbuild.OnResolveOptions{Filter: `^` + reFrom}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+						log.Debugf("rewrote import %q to %q", args.Path, imports[from]+args.Path[len(from):])
+						result.Path = imports[from] + args.Path[len(from):]
+						result.Namespace = httpNamespace
+						if external {
+							result.External = true
+						}
+						return result, nil
+					})
+					continue
+				}
+				epb.OnResolve(esbuild.OnResolveOptions{Filter: `^` + reFrom + `$`}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+					log.Debugf("rewrote import %q to %q", args.Path, to)
+					result.Path = to
+					result.Namespace = httpNamespace
+					if external {
+						result.External = true
+					}
+					return result, nil
+				})
+			}
+		},
+	}
+}

--- a/package/es/importmap_test.go
+++ b/package/es/importmap_test.go
@@ -1,0 +1,47 @@
+package es_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/is"
+	"github.com/livebud/bud/internal/versions"
+	"github.com/livebud/bud/package/es"
+	"github.com/livebud/bud/package/log/testlog"
+	"github.com/livebud/bud/package/testdir"
+)
+
+func TestImportMap(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	log := testlog.New()
+	td, err := testdir.Load()
+	is.NoErr(err)
+	td.Files["view/index.js"] = `
+		import { SvelteComponent } from 'svelte'
+		import { create_component } from 'svelte/internal'
+		export function createElement() { console.log(SvelteComponent, create_component) }
+	`
+	is.NoErr(td.Write(ctx))
+	flag := &framework.Flag{}
+	esb := es.New(flag, log)
+	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
+		Entry:    "./view/index.js",
+		Platform: es.DOM,
+		Plugins: []es.Plugin{
+			es.HTTP(http.DefaultClient),
+			es.ImportMap(log, map[string]string{
+				"svelte":  "https://esm.run/svelte@" + versions.Svelte,
+				"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
+			}),
+		},
+	})
+	is.NoErr(err)
+	code := string(file.Contents)
+	is.In(code, `function createElement() {`)
+	is.In(code, `"Component was already destroyed"`)
+	is.In(code, `on_mount`)
+}

--- a/package/es/nodemodules.go
+++ b/package/es/nodemodules.go
@@ -1,0 +1,22 @@
+package es
+
+import (
+	"path"
+
+	esbuild "github.com/evanw/esbuild/pkg/api"
+)
+
+// ExternalNodeModules externalizes node_modules
+func ExternalNodeModules(prefix string) esbuild.Plugin {
+	return esbuild.Plugin{
+		Name: "external_node_modules",
+		Setup: func(epb esbuild.PluginBuild) {
+			// Regexp doesn't start with "." or "/" or "\"
+			epb.OnResolve(esbuild.OnResolveOptions{Filter: `^[^\.\/\\]`}, func(args esbuild.OnResolveArgs) (result esbuild.OnResolveResult, err error) {
+				result.Path = path.Join(prefix, args.Path)
+				result.External = true
+				return result, nil
+			})
+		},
+	}
+}

--- a/package/es/serve_test.go
+++ b/package/es/serve_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/internal/is"
 	"github.com/livebud/bud/package/es"
-	"github.com/livebud/bud/package/gomod"
 	v8 "github.com/livebud/bud/package/js/v8"
 	"github.com/livebud/bud/package/log/testlog"
 	"github.com/livebud/bud/package/testdir"
@@ -48,10 +47,9 @@ func TestServeSSR(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "./view/index.jsx",
 		Platform: es.SSR,
 	})
@@ -97,12 +95,14 @@ func TestServeDOM(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "./view/index.jsx",
 		Platform: es.DOM,
+		Plugins: []es.Plugin{
+			es.ExternalNodeModules("/node_modules"),
+		},
 	})
 	is.NoErr(err)
 	code := string(file.Contents)
@@ -128,10 +128,9 @@ func TestServeModuleDOM(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "react",
 		Platform: es.DOM,
 	})
@@ -155,10 +154,9 @@ func TestServeRelModuleDOM(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "./node_modules/react",
 		Platform: es.DOM,
 	})
@@ -184,10 +182,9 @@ func TestServeRelModuleSubpathDOM(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "./node_modules/react/client",
 		Platform: es.DOM,
 	})
@@ -213,10 +210,9 @@ func TestServeScopedModuleDOM(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "@pkg/slugify",
 		Platform: es.DOM,
 	})
@@ -244,10 +240,9 @@ func TestServeRelScopedModuleSubpathDOM(t *testing.T) {
 	`
 	is.NoErr(td.Write(ctx))
 	flag := &framework.Flag{}
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	file, err := esb.Serve(&es.Serve{
+		AbsDir:   td.Directory(),
 		Entry:    "./node_modules/@pkg/slugify/client",
 		Platform: es.DOM,
 	})
@@ -258,7 +253,6 @@ func TestServeRelScopedModuleSubpathDOM(t *testing.T) {
 	is.In(code, "export {\n  slugify as default\n};")
 }
 
-// TODO: Test serve DOM node_module entry (e.g. "./node_modules/react")
 // TODO: test resolving different relative path extensions (e.g. ./Header.svelte)
 // TODO: test resolving different node_modules path extensions (e.g. "./node_modules/@ui/Grid.svelte")
 // TODO: test dependencies of dependencies

--- a/package/valid/valid.go
+++ b/package/valid/valid.go
@@ -51,6 +51,8 @@ func invalidView(name string) bool {
 		name == "bud" || // Named bud (reserved)
 		ext == "" || // No extension
 		ext == ".go" || // Go files
+		name == "go.sum" || name == "go.mod" || // Go mod files
+		name == "package.json" || // Node package file
 		unicode.IsUpper(firstRune(name)) // Starts with a capital letter
 }
 

--- a/package/valid/valid.go
+++ b/package/valid/valid.go
@@ -37,17 +37,20 @@ func PluginDir(name string) bool {
 		strings.ToLower(name) != name // Has uppercase letters
 }
 
-// ViewEntry validates that name matches a valid view entrypoint
-func ViewEntry(name string) bool {
-	return !invalidViewEntry(name)
+// View validates that name matches a valid view
+func View(name string) bool {
+	return !invalidView(name)
 }
 
-// Invalid view entry check
-func invalidViewEntry(name string) bool {
+// Invalid view check
+func invalidView(name string) bool {
+	ext := path.Ext(name)
 	return len(name) == 0 || // Empty string
 		name[0] == '_' || // Starts with _
 		name[0] == '.' || // Starts with .
 		name == "bud" || // Named bud (reserved)
+		ext == "" || // No extension
+		ext == ".go" || // Go files
 		unicode.IsUpper(firstRune(name)) // Starts with a capital letter
 }
 

--- a/package/valid/valid_test.go
+++ b/package/valid/valid_test.go
@@ -47,6 +47,9 @@ func TestView(t *testing.T) {
 	is.True(!valid.View("A"))
 	is.True(!valid.View("Ab"))
 	is.True(!valid.View("bud"))
+	is.True(!valid.View("go.mod"))
+	is.True(!valid.View("go.sum"))
+	is.True(!valid.View("package.json"))
 }
 
 func TestControllerFile(t *testing.T) {

--- a/package/valid/valid_test.go
+++ b/package/valid/valid_test.go
@@ -26,23 +26,27 @@ func TestDir(t *testing.T) {
 	is.True(!valid.Dir("bud"))
 }
 
-func TestViewEntry(t *testing.T) {
+func TestView(t *testing.T) {
 	is := is.New(t)
-	is.True(valid.ViewEntry("a"))
-	is.True(valid.ViewEntry("ab"))
-	is.True(valid.ViewEntry("a_"))
-	is.True(valid.ViewEntry("ab_"))
-	is.True(valid.ViewEntry("ab-"))
-	is.True(valid.ViewEntry("aA"))
-	is.True(valid.ViewEntry("aB"))
-	is.True(!valid.ViewEntry(""))
-	is.True(!valid.ViewEntry("_a"))
-	is.True(!valid.ViewEntry("_ab"))
-	is.True(!valid.ViewEntry(".a"))
-	is.True(!valid.ViewEntry(".ab"))
-	is.True(!valid.ViewEntry("A"))
-	is.True(!valid.ViewEntry("Ab"))
-	is.True(!valid.ViewEntry("bud"))
+	is.True(valid.View("a.jsx"))
+	is.True(valid.View("a.svelte"))
+	is.True(valid.View("a.svg"))
+	is.True(valid.View("ab.jsx"))
+	is.True(valid.View("ab.svelte"))
+	is.True(valid.View("ab.svg"))
+	is.True(valid.View("a_.jsx"))
+	is.True(valid.View("ab_.jsx"))
+	is.True(valid.View("ab-.jsx"))
+	is.True(valid.View("aA.jsx"))
+	is.True(valid.View("aB.jsx"))
+	is.True(!valid.View(""))
+	is.True(!valid.View("_a"))
+	is.True(!valid.View("_ab"))
+	is.True(!valid.View(".a"))
+	is.True(!valid.View(".ab"))
+	is.True(!valid.View("A"))
+	is.True(!valid.View("Ab"))
+	is.True(!valid.View("bud"))
 }
 
 func TestControllerFile(t *testing.T) {

--- a/package/viewer/find.go
+++ b/package/viewer/find.go
@@ -193,10 +193,18 @@ func extless(path string) string {
 	return path
 }
 
-func viewClient(fpath string) string {
-	return "/view/" + path.Clean(fpath) + ".js"
+func viewClient(fpath string) *Client {
+	viewPath := path.Clean(fpath) + ".js"
+	return &Client{
+		Path:  viewPath,
+		Route: "/view/" + viewPath,
+	}
 }
 
-func entryClient(fpath string) string {
-	return "/view/" + path.Clean(fpath) + ".entry.js"
+func entryClient(fpath string) *Client {
+	entryPath := path.Clean(fpath) + ".entry.js"
+	return &Client{
+		Path:  entryPath,
+		Route: "/view/" + entryPath,
+	}
 }

--- a/package/viewer/find.go
+++ b/package/viewer/find.go
@@ -4,6 +4,10 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
+	"strings"
+
+	"github.com/livebud/bud/package/valid"
+	"github.com/matthewmueller/text"
 
 	"github.com/livebud/bud/internal/gitignore"
 )
@@ -47,26 +51,29 @@ func find(fsys FS, ignore func(path string) bool, pages map[Key]*Page, inherited
 			continue
 		}
 		ext := filepath.Ext(de.Name())
-		extless := de.Name()[:len(de.Name())-len(ext)]
+		extless := extless(de.Name())
 		key := path.Join(dir, extless)
 		switch extless {
 		case "layout":
 			inherited.Layout[ext] = &View{
-				Path: fpath,
-				Key:  key,
-				Ext:  ext,
+				Path:   fpath,
+				Key:    key,
+				Ext:    ext,
+				Client: viewClient(fpath),
 			}
 		case "frame":
 			inherited.Frames[ext] = append(inherited.Frames[ext], &View{
-				Path: fpath,
-				Key:  key,
-				Ext:  ext,
+				Path:   fpath,
+				Key:    key,
+				Ext:    ext,
+				Client: viewClient(fpath),
 			})
 		case "error":
 			inherited.Error[ext] = &View{
-				Path: fpath,
-				Key:  key,
-				Ext:  ext,
+				Path:   fpath,
+				Key:    key,
+				Ext:    ext,
+				Client: viewClient(fpath),
 			}
 		}
 	}
@@ -77,21 +84,28 @@ func find(fsys FS, ignore func(path string) bool, pages map[Key]*Page, inherited
 			continue
 		}
 		ext := filepath.Ext(de.Name())
-		extless := de.Name()[:len(de.Name())-len(ext)]
+		if !valid.View(de.Name()) {
+			continue
+		}
+		extless := extless(de.Name())
 		switch extless {
 		case "layout", "frame", "error":
 			continue
 		default:
 			key := path.Join(dir, extless)
+			fpath := path.Join(dir, de.Name())
 			pages[key] = &Page{
 				View: &View{
-					Path: path.Join(dir, de.Name()),
-					Key:  key,
-					Ext:  ext,
+					Path:   fpath,
+					Key:    key,
+					Ext:    ext,
+					Client: viewClient(fpath),
 				},
 				Layout: inherited.Layout[ext],
 				Frames: inherited.Frames[ext],
 				Error:  inherited.Error[ext],
+				Route:  route(dir, extless),
+				Client: entryClient(fpath),
 			}
 		}
 	}
@@ -111,4 +125,62 @@ func find(fsys FS, ignore func(path string) bool, pages map[Key]*Page, inherited
 	}
 
 	return nil
+}
+
+// Generate the IDs for a nested route
+// TODO: consolidate with the function in internal/generator/action/loader.go.
+func routeDir(dir string) string {
+	segments := strings.Split(dir, "/")
+	path := new(strings.Builder)
+	for i := 0; i < len(segments); i++ {
+		if i%2 != 0 {
+			path.WriteString("/")
+			path.WriteString(":" + text.Snake(text.Singular(segments[i-1])) + "_id")
+			path.WriteString("/")
+		}
+		path.WriteString(text.Snake(segments[i]))
+	}
+	if path.Len() == 0 {
+		return ""
+	}
+	return path.String()
+}
+
+// Path is the route to the action
+func route(dir, extless string) string {
+	dir = strings.TrimPrefix(strings.TrimPrefix(dir, "view"), "/")
+	if dir == "." {
+		dir = ""
+	}
+	dir = routeDir(dir)
+	switch extless {
+	case "show":
+		return "/" + path.Join(dir, ":id")
+	case "new":
+		return "/" + path.Join(dir, "new")
+	case "edit":
+		return "/" + path.Join(dir, ":id", "edit")
+	case "index":
+		return "/" + dir
+	default:
+		return "/" + path.Join(dir, text.Lower(text.Snake(extless)))
+	}
+}
+
+// Recursively trim file extensions until there aren't any left
+func extless(path string) string {
+	ext := filepath.Ext(path)
+	for ext != "" {
+		path = strings.TrimSuffix(path, ext)
+		ext = filepath.Ext(path)
+	}
+	return path
+}
+
+func viewClient(fpath string) string {
+	return "/view/" + path.Clean(fpath) + ".js"
+}
+
+func entryClient(fpath string) string {
+	return "/view/" + path.Clean(fpath) + ".entry.js"
 }

--- a/package/viewer/find_test.go
+++ b/package/viewer/find_test.go
@@ -38,18 +38,64 @@ func TestNested(t *testing.T) {
 	is.Equal(len(pages), 1)
 	is.True(pages["posts/index"] != nil)
 	is.Equal(pages["posts/index"].Path, "posts/index.svelte")
+	is.Equal(pages["posts/index"].Client, "/view/posts/index.svelte.entry.js")
+	is.Equal(pages["posts/index"].View.Client, "/view/posts/index.svelte.js")
+	is.Equal(pages["posts/index"].Route, "/posts")
 
 	// Frames
 	is.Equal(len(pages["posts/index"].Frames), 2)
-	is.Equal(pages["posts/index"].Frames[0].Key, "frame")
-	is.Equal(pages["posts/index"].Frames[0].Path, "frame.svelte")
-	is.Equal(pages["posts/index"].Frames[1].Key, "posts/frame")
-	is.Equal(pages["posts/index"].Frames[1].Path, "posts/frame.svelte")
+	is.Equal(pages["posts/index"].Frames[0].Key, "posts/frame")
+	is.Equal(pages["posts/index"].Frames[0].Path, "posts/frame.svelte")
+	is.Equal(pages["posts/index"].Frames[0].Client, "/view/posts/frame.svelte.js")
+	is.Equal(pages["posts/index"].Frames[1].Key, "frame")
+	is.Equal(pages["posts/index"].Frames[1].Path, "frame.svelte")
+	is.Equal(pages["posts/index"].Frames[1].Client, "/view/frame.svelte.js")
 
+	// Error page
 	is.Equal(pages["posts/index"].Error, nil)
 
 	// Layout
 	is.True(pages["posts/index"].Layout != nil)
 	is.Equal(pages["posts/index"].Layout.Key, "layout")
 	is.Equal(pages["posts/index"].Layout.Path, "layout.svelte")
+	// Layout is server-side only
+	is.Equal(pages["posts/index"].Layout.Client, "")
+}
+
+func TestError(t *testing.T) {
+	is := is.New(t)
+	fsys := fstest.MapFS{
+		"layout.svelte":      &fstest.MapFile{Data: []byte(`<slot />`)},
+		"frame.svelte":       &fstest.MapFile{Data: []byte(`<slot />`)},
+		"error.svelte":       &fstest.MapFile{Data: []byte(`<h1>Oops!</h1>`)},
+		"posts/frame.svelte": &fstest.MapFile{Data: []byte(`<slot />`)},
+		"posts/index.svelte": &fstest.MapFile{Data: []byte(`<h1>Hello {planet}!</h1>`)},
+	}
+	// Find the pages
+	pages, err := viewer.Find(fsys)
+	is.NoErr(err)
+	is.Equal(len(pages), 2)
+
+	is.True(pages["error"] != nil)
+	is.Equal(pages["error"].Key, "error")
+	is.Equal(pages["error"].Path, "error.svelte")
+	is.Equal(pages["error"].Client, "/view/error.svelte.entry.js")
+	is.Equal(pages["error"].View.Client, "/view/error.svelte.js")
+	is.Equal(pages["error"].Route, "/error")
+
+	// Frames
+	is.Equal(len(pages["error"].Frames), 1)
+	is.Equal(pages["error"].Frames[0].Key, "frame")
+	is.Equal(pages["error"].Frames[0].Path, "frame.svelte")
+	is.Equal(pages["error"].Frames[0].Client, "/view/frame.svelte.js")
+
+	// Error page
+	is.Equal(pages["error"].Error, nil)
+
+	// Layout
+	is.True(pages["error"].Layout != nil)
+	is.Equal(pages["error"].Layout.Key, "layout")
+	is.Equal(pages["error"].Layout.Path, "layout.svelte")
+	// Layout is server-side only
+	is.Equal(pages["error"].Layout.Client, "")
 }

--- a/package/viewer/find_test.go
+++ b/package/viewer/find_test.go
@@ -38,18 +38,26 @@ func TestNested(t *testing.T) {
 	is.Equal(len(pages), 1)
 	is.True(pages["posts/index"] != nil)
 	is.Equal(pages["posts/index"].Path, "posts/index.svelte")
-	is.Equal(pages["posts/index"].Client, "/view/posts/index.svelte.entry.js")
-	is.Equal(pages["posts/index"].View.Client, "/view/posts/index.svelte.js")
+	is.True(pages["posts/index"].Client != nil)
+	is.Equal(pages["posts/index"].Client.Route, "/view/posts/index.svelte.entry.js")
+	is.Equal(pages["posts/index"].Client.Path, "posts/index.svelte.entry.js")
+	is.True(pages["posts/index"].View.Client != nil)
+	is.Equal(pages["posts/index"].View.Client.Route, "/view/posts/index.svelte.js")
+	is.Equal(pages["posts/index"].View.Client.Path, "posts/index.svelte.js")
 	is.Equal(pages["posts/index"].Route, "/posts")
 
 	// Frames
 	is.Equal(len(pages["posts/index"].Frames), 2)
 	is.Equal(pages["posts/index"].Frames[0].Key, "posts/frame")
 	is.Equal(pages["posts/index"].Frames[0].Path, "posts/frame.svelte")
-	is.Equal(pages["posts/index"].Frames[0].Client, "/view/posts/frame.svelte.js")
+	is.True(pages["posts/index"].Frames[0].Client != nil)
+	is.Equal(pages["posts/index"].Frames[0].Client.Route, "/view/posts/frame.svelte.js")
+	is.Equal(pages["posts/index"].Frames[0].Client.Path, "posts/frame.svelte.js")
 	is.Equal(pages["posts/index"].Frames[1].Key, "frame")
 	is.Equal(pages["posts/index"].Frames[1].Path, "frame.svelte")
-	is.Equal(pages["posts/index"].Frames[1].Client, "/view/frame.svelte.js")
+	is.True(pages["posts/index"].Frames[1].Client != nil)
+	is.Equal(pages["posts/index"].Frames[1].Client.Route, "/view/frame.svelte.js")
+	is.Equal(pages["posts/index"].Frames[1].Client.Path, "frame.svelte.js")
 
 	// Error page
 	is.Equal(pages["posts/index"].Error, nil)
@@ -59,7 +67,7 @@ func TestNested(t *testing.T) {
 	is.Equal(pages["posts/index"].Layout.Key, "layout")
 	is.Equal(pages["posts/index"].Layout.Path, "layout.svelte")
 	// Layout is server-side only
-	is.Equal(pages["posts/index"].Layout.Client, "")
+	is.Equal(pages["posts/index"].Layout.Client, nil)
 }
 
 func TestError(t *testing.T) {
@@ -79,15 +87,21 @@ func TestError(t *testing.T) {
 	is.True(pages["error"] != nil)
 	is.Equal(pages["error"].Key, "error")
 	is.Equal(pages["error"].Path, "error.svelte")
-	is.Equal(pages["error"].Client, "/view/error.svelte.entry.js")
-	is.Equal(pages["error"].View.Client, "/view/error.svelte.js")
+	is.True(pages["error"].Client != nil)
+	is.Equal(pages["error"].Client.Route, "/view/error.svelte.entry.js")
+	is.Equal(pages["error"].Client.Path, "error.svelte.entry.js")
+	is.True(pages["error"].View.Client != nil)
+	is.Equal(pages["error"].View.Client.Route, "/view/error.svelte.js")
+	is.Equal(pages["error"].View.Client.Path, "error.svelte.js")
 	is.Equal(pages["error"].Route, "/error")
 
 	// Frames
 	is.Equal(len(pages["error"].Frames), 1)
 	is.Equal(pages["error"].Frames[0].Key, "frame")
 	is.Equal(pages["error"].Frames[0].Path, "frame.svelte")
-	is.Equal(pages["error"].Frames[0].Client, "/view/frame.svelte.js")
+	is.True(pages["error"].Frames[0].Client != nil)
+	is.Equal(pages["error"].Frames[0].Client.Route, "/view/frame.svelte.js")
+	is.Equal(pages["error"].Frames[0].Client.Path, "frame.svelte.js")
 
 	// Error page
 	is.Equal(pages["error"].Error, nil)
@@ -97,5 +111,27 @@ func TestError(t *testing.T) {
 	is.Equal(pages["error"].Layout.Key, "layout")
 	is.Equal(pages["error"].Layout.Path, "layout.svelte")
 	// Layout is server-side only
-	is.Equal(pages["error"].Layout.Client, "")
+	is.Equal(pages["error"].Layout.Client, nil)
+}
+
+func TestComponent(t *testing.T) {
+	is := is.New(t)
+	fsys := fstest.MapFS{
+		"Component.svelte": &fstest.MapFile{Data: []byte(`<h1>Hello</h1>`)},
+	}
+	// Find the pages
+	pages, err := viewer.Find(fsys)
+	is.NoErr(err)
+	is.Equal(len(pages), 0)
+}
+
+func TestUnderscore(t *testing.T) {
+	is := is.New(t)
+	fsys := fstest.MapFS{
+		"_index.svelte": &fstest.MapFile{Data: []byte(`<h1>Hello</h1>`)},
+	}
+	// Find the pages
+	pages, err := viewer.Find(fsys)
+	is.NoErr(err)
+	is.Equal(len(pages), 0)
 }

--- a/package/viewer/gohtml/gohtml.go
+++ b/package/viewer/gohtml/gohtml.go
@@ -96,34 +96,48 @@ func (v *Viewer) Render(ctx context.Context, key string, propMap viewer.PropMap)
 func (v *Viewer) RenderError(ctx context.Context, key string, propMap viewer.PropMap, originalError error) []byte {
 	page, ok := v.pages[key]
 	if !ok {
-		return []byte(fmt.Sprintf("gohtml: unable to find page from key %q to render error %s", key, originalError))
+		return []byte(fmt.Sprintf("gohtml: unable to find page from key %q to render error. %s", key, originalError))
 	}
-	v.log.Info("gohtml: rendering error", page.Error.Path)
-	errorEntry, err := v.parseTemplate(page.Error.Path)
+	if page.Error == nil {
+		return []byte(fmt.Sprintf("gohtml: page %q has no error page to render error. %s", key, originalError))
+	}
+	errorPage, ok := v.pages[page.Error.Key]
+	if !ok {
+		return []byte(fmt.Sprintf("gohtml: unable to find error page from key %q to render error. %s", page.Error.Key, originalError))
+	}
+	v.log.Info("gohtml: rendering error", errorPage.Path)
+	errorEntry, err := v.parseTemplate(errorPage.Path)
 	if err != nil {
-		return []byte(fmt.Sprintf("gohtml: unable to read error template %q to render error %s. %s", page.Error.Path, err, originalError))
+		return []byte(fmt.Sprintf("gohtml: unable to read error template %q to render error %s. %s", errorPage.Path, err, originalError))
 	}
-	// TODO: support frames
-	layout, err := v.parseTemplate(page.Layout.Path)
+	frames := make([]*template.Template, len(errorPage.Frames))
+	for i, frame := range errorPage.Frames {
+		frameEntry, err := v.parseTemplate(frame.Path)
+		if err != nil {
+			return []byte(fmt.Sprintf("gohtml: unable to read frame template %q to render error %s. %s", frame.Path, err, originalError))
+		}
+		frames[i] = frameEntry
+	}
+	layout, err := v.parseTemplate(errorPage.Layout.Path)
 	if err != nil {
-		return []byte(fmt.Sprintf("gohtml: unable to parse layout template %q to render error %s. %s", page.Error.Path, err, originalError))
+		return []byte(fmt.Sprintf("gohtml: unable to parse layout template %q to render error %s. %s", errorPage.Path, err, originalError))
 	}
-	state := errorState{
-		Message: originalError.Error(),
-	}
-	html, err := render(ctx, errorEntry, state)
+	html, err := render(ctx, errorEntry, viewer.Error(originalError))
 	if err != nil {
-		return []byte(fmt.Sprintf("gohtml: unable to render error template %q to render error %s. %s", page.Error.Path, err, originalError))
+		return []byte(fmt.Sprintf("gohtml: unable to render error template %q to render error %s. %s", errorPage.Path, err, originalError))
+	}
+	for i, frame := range errorPage.Frames {
+		// TODO: support other props
+		html, err = render(ctx, frames[i], template.HTML(html))
+		if err != nil {
+			return []byte(fmt.Sprintf("gohtml: unable to render frame template %q to render error %s. %s", frame.Path, err, originalError))
+		}
 	}
 	html, err = render(ctx, layout, template.HTML(html))
 	if err != nil {
-		return []byte(fmt.Sprintf("gohtml: unable to render layout template %q to render error %s. %s", page.Error.Path, err, originalError))
+		return []byte(fmt.Sprintf("gohtml: unable to render layout template %q to render error %s. %s", errorPage.Path, err, originalError))
 	}
 	return html
-}
-
-type errorState struct {
-	Message string
 }
 
 func (v *Viewer) Bundle(ctx context.Context, fs virtual.Tree) (err error) {
@@ -161,14 +175,14 @@ func (v *Viewer) Bundle(ctx context.Context, fs virtual.Tree) (err error) {
 
 		// Embed the error
 		if page.Error != nil {
-			if _, ok := fs[page.Error.Path]; ok {
+			if _, ok := fs[page.Path]; ok {
 				continue
 			}
-			errorEmbed, err := v.embedView(page.Error.Path)
+			errorEmbed, err := v.embedView(page.Path)
 			if err != nil {
 				return err
 			}
-			fs[page.Error.Path] = errorEmbed
+			fs[page.Path] = errorEmbed
 		}
 	}
 	return nil

--- a/package/viewer/gohtml/gohtml.go
+++ b/package/viewer/gohtml/gohtml.go
@@ -103,6 +103,7 @@ func (v *Viewer) RenderError(ctx context.Context, key string, propMap viewer.Pro
 	if err != nil {
 		return []byte(fmt.Sprintf("gohtml: unable to read error template %q to render error %s. %s", page.Error.Path, err, originalError))
 	}
+	// TODO: support frames
 	layout, err := v.parseTemplate(page.Layout.Path)
 	if err != nil {
 		return []byte(fmt.Sprintf("gohtml: unable to parse layout template %q to render error %s. %s", page.Error.Path, err, originalError))

--- a/package/viewer/gohtml/gohtml_test.go
+++ b/package/viewer/gohtml/gohtml_test.go
@@ -57,19 +57,57 @@ func TestRenderError(t *testing.T) {
 	log := testlog.New()
 	fsys := virtual.Map{
 		"index.gohtml":  "Hello {{ .Planet }}!",
+		"frame.gohtml":  `<main>{{ . }}</main>`,
 		"layout.gohtml": "<html>{{ . }}</html>",
 		"error.gohtml":  `<div class="error">{{ .Message }}</div>`,
 	}
 	pages, err := viewer.Find(fsys)
 	is.NoErr(err)
-	viewer := gohtml.New(fsys, log, pages, transpiler.New())
+	gohtml := gohtml.New(fsys, log, pages, transpiler.New())
 	ctx := context.Background()
-	html := viewer.RenderError(ctx, "index", map[string]interface{}{
-		"index": map[string]interface{}{
-			"Planet": "Earth",
-		},
+	html := gohtml.RenderError(ctx, "index", map[string]interface{}{
+		"index": map[string]interface{}{"Planet": "Earth"},
 	}, errors.New("some error"))
-	is.Equal(string(html), `<html><div class="error">some error</div></html>`)
+	is.Equal(string(html), `<html><main><div class="error">some error</div></main></html>`)
+}
+
+// TODO: this should have a default page
+func TestRenderErrorNoPage(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	fsys := virtual.Map{
+		"index.gohtml":  "Hello {{ .Planet }}!",
+		"frame.gohtml":  `<main>{{ . }}</main>`,
+		"layout.gohtml": "<html>{{ . }}</html>",
+	}
+	pages, err := viewer.Find(fsys)
+	is.NoErr(err)
+	gohtml := gohtml.New(fsys, log, pages, transpiler.New())
+	ctx := context.Background()
+	html := gohtml.RenderError(ctx, "index", map[string]interface{}{
+		"index": map[string]interface{}{"Planet": "Earth"},
+	}, errors.New("some error"))
+	is.Equal(string(html), `gohtml: page "index" has no error page to render error. some error`)
+}
+
+func TestRenderErrorWithFrames(t *testing.T) {
+	is := is.New(t)
+	log := testlog.New()
+	fsys := virtual.Map{
+		"posts/index.gohtml": "Hello {{ .Planet }}!",
+		"posts/frame.gohtml": `<div class="posts">{{ . }}</div>`,
+		"frame.gohtml":       `<main>{{ . }}</main>`,
+		"layout.gohtml":      "<html>{{ . }}</html>",
+		"error.gohtml":       `<div class="error">{{ .Message }}</div>`,
+	}
+	pages, err := viewer.Find(fsys)
+	is.NoErr(err)
+	gohtml := gohtml.New(fsys, log, pages, transpiler.New())
+	ctx := context.Background()
+	html := gohtml.RenderError(ctx, "posts/index", map[string]interface{}{
+		"posts/index": map[string]interface{}{"Planet": "Earth"},
+	}, errors.New("some error"))
+	is.Equal(string(html), `<html><main><div class="error">some error</div></main></html>`)
 }
 
 func TestBundle(t *testing.T) {

--- a/package/viewer/svelte/dom_entry.gotext
+++ b/package/viewer/svelte/dom_entry.gotext
@@ -30,7 +30,6 @@ mount({
 	error: "{{ $.Page.Error.Key }}",
 	{{- end }}
 	components: components,
-	client: "{{ $.Page.Client }}",
 	{{- if $.Hot }}
 	hot: new Hot("http://127.0.0.1:35729/bud/hot/{{$.Page.Key}}", components),
 	{{- end }}

--- a/package/viewer/svelte/dom_entry.gotext
+++ b/package/viewer/svelte/dom_entry.gotext
@@ -1,10 +1,10 @@
 {{/* dom_entry.gotext is the entrypoint for hydrating a page */}}
 
 {{- range $import := $.Imports }}
-import {{ $import.Name }} from "/view/index.svelte.js"
+import {{ $import.Name }} from "{{ $import.Path }}"
 {{- end }}
 
-import { mount } from "svelte_dom_runtime";
+import { mount } from ".svelte_dom_runtime";
 {{- if $.Hot }}
 import Hot from "livebud/runtime/hot"
 {{- end }}

--- a/package/viewer/svelte/dom_runtime.ts
+++ b/package/viewer/svelte/dom_runtime.ts
@@ -11,7 +11,6 @@ type Page = {
   components: {
     [key: string]: typeof SvelteComponentTyped
   }
-  client: string
   hot?: Hot
 }
 

--- a/package/viewer/svelte/ssr_entry.gotext
+++ b/package/viewer/svelte/ssr_entry.gotext
@@ -9,7 +9,7 @@ import { Page } from ".svelte_ssr_runtime";
 const page = new Page({
 	key: "{{ $.Page.Key }}",
 	Component: {{ $.Page.Component }},
-	client: "{{ $.Page.Client }}",
+	client: "{{ $.Page.Client.Route }}",
 	{{- if $.Page.Layout }}
 	layout: {
 		key: "{{ $.Page.Layout.Key }}",

--- a/package/viewer/svelte/ssr_entry.gotext
+++ b/package/viewer/svelte/ssr_entry.gotext
@@ -4,7 +4,7 @@
 import {{ $import.Name }} from "./{{ $import.Path }}"
 {{- end }}
 
-import { Page } from "svelte_ssr_runtime";
+import { Page } from ".svelte_ssr_runtime";
 
 const page = new Page({
 	key: "{{ $.Page.Key }}",

--- a/package/viewer/svelte/ssr_runtime.ts
+++ b/package/viewer/svelte/ssr_runtime.ts
@@ -59,7 +59,7 @@ export class Page {
       const layoutProps = props[layout.key] || {}
       // Don't pass layout props down to the client
       delete props[layout.key]
-      const clientScript = `<script src="${client}" async defer></script>`
+      const clientScript = `<script src="${client}" type="module" async defer></script>`
       const { head, css, html: layoutHTML } = layout.Component.render(layoutProps, {
         // context: new Map(Object.entries(page.layout?.context || {})),
         '$$slots': {

--- a/package/viewer/svelte/static.go
+++ b/package/viewer/svelte/static.go
@@ -1,0 +1,166 @@
+package svelte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/router"
+	"github.com/livebud/bud/package/viewer"
+	"github.com/livebud/bud/package/virtual"
+	"github.com/livebud/js"
+)
+
+func Static(fsys fs.FS, js js.VM, log log.Log, pages viewer.Pages) *StaticViewer {
+	return &StaticViewer{fsys, http.FS(fsys), js, log, pages}
+}
+
+type StaticViewer struct {
+	fsys  fs.FS
+	hfs   http.FileSystem
+	js    js.VM
+	log   log.Log
+	pages viewer.Pages
+}
+
+var _ viewer.Viewer = (*StaticViewer)(nil)
+
+func (v *StaticViewer) Mount(r *router.Router) error {
+	for _, page := range v.pages {
+		// Serve the entrypoints (for hydrating)
+		r.Get(page.Client.Route, v.serveDOMEntry(page))
+		// Serve the individual views themselves
+		r.Get(page.View.Client.Route, v.serveDOMView(page.View))
+	}
+	return nil
+}
+
+func (v *StaticViewer) Render(ctx context.Context, key string, propMap viewer.PropMap) ([]byte, error) {
+	page, ok := v.pages[key]
+	if !ok {
+		return nil, fmt.Errorf("svelte: unable to find page from key %q", key)
+	}
+	v.log.Info("svelte: rendering", page.Path)
+	code, err := fs.ReadFile(v.fsys, page.Path)
+	if err != nil {
+		return nil, err
+	}
+	propBytes, err := json.Marshal(propMap)
+	if err != nil {
+		return nil, err
+	}
+	expr := fmt.Sprintf(`%s; bud.render(%s)`, string(code), propBytes)
+	html, err := v.js.Evaluate(ctx, page.Path, expr)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(html), nil
+}
+
+func (v *StaticViewer) RenderError(ctx context.Context, key string, propMap viewer.PropMap, originalError error) []byte {
+	page, ok := v.pages[key]
+	if !ok {
+		return []byte(fmt.Sprintf("svelte: unable to find page from key %q to render error. %s", key, originalError))
+	}
+	if page.Error == nil {
+		return []byte(fmt.Sprintf("svelte: no error page for %q to render error. %s", key, originalError))
+	}
+	errorPage, ok := v.pages[page.Error.Key]
+	if !ok {
+		return []byte(fmt.Sprintf("svelte: unable to find error page for %q to render error. %s", page.Error.Key, originalError))
+	}
+	v.log.Info("svelte: rendering error", errorPage.Path)
+	code, err := fs.ReadFile(v.fsys, errorPage.Path)
+	if err != nil {
+		return []byte(fmt.Sprintf("svelte: unable to read error page %q code to render error. %s. %s", errorPage.Path, err, originalError))
+	}
+	propMap[errorPage.Key] = viewer.Error(originalError)
+	propBytes, err := json.Marshal(propMap)
+	if err != nil {
+		return []byte(fmt.Sprintf("svelte: unable to marshal props for %q to render error. %s. %s", errorPage.Path, err, originalError))
+	}
+	expr := fmt.Sprintf(`%s; bud.render(%s)`, code, propBytes)
+	html, err := v.js.Evaluate(ctx, errorPage.Path, expr)
+	if err != nil {
+		return []byte(fmt.Sprintf("svelte: unable to evaluate javascript to render %q to render error. %s. %s", errorPage.Path, err, originalError))
+	}
+	return []byte(html)
+}
+
+// TODO: split Viewer into Bundler and Renderer interfaces.
+func (v *StaticViewer) Bundle(ctx context.Context, embed virtual.Tree) error {
+	return fmt.Errorf("can't bundle with the static viewer")
+}
+
+func (v *StaticViewer) Handler(page *viewer.Page) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		propMap, err := viewer.StaticPropMap(page, r)
+		if err != nil {
+			v.renderError(ctx, w, page, propMap, err)
+			return
+		}
+		html, err := v.Render(ctx, page.Key, propMap)
+		if err != nil {
+			v.renderError(ctx, w, page, propMap, err)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(html)
+	})
+}
+
+func (v *StaticViewer) renderError(ctx context.Context, w http.ResponseWriter, page *viewer.Page, propMap map[string]interface{}, err error) {
+	html := v.RenderError(ctx, page.Key, propMap, err)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write(html)
+}
+
+func (v *StaticViewer) serveDOMEntry(page *viewer.Page) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v.log.Info("svelte: serving dom entry", page.Client.Path)
+		file, err := v.hfs.Open(page.Client.Path)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer file.Close()
+		stat, err := file.Stat()
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		if stat.IsDir() {
+			http.Error(w, fmt.Sprintf("%q is a directory", r.URL.Path), 500)
+			return
+		}
+		http.ServeContent(w, r, page.Client.Path, stat.ModTime(), file)
+	})
+}
+
+func (v *StaticViewer) serveDOMView(view *viewer.View) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v.log.Info("svelte: serving dom view", view.Client.Path)
+		file, err := v.hfs.Open(view.Client.Path)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer file.Close()
+		stat, err := file.Stat()
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		if stat.IsDir() {
+			http.Error(w, fmt.Sprintf("%q is a directory", r.URL.Path), 500)
+			return
+		}
+		http.ServeContent(w, r, view.Client.Path, stat.ModTime(), file)
+	})
+}

--- a/package/viewer/svelte/svelte.go
+++ b/package/viewer/svelte/svelte.go
@@ -448,7 +448,8 @@ func (v *Viewer) domEntryPlugin(page *viewer.Page) es.Plugin {
 				}
 				state.Imports = imports.List()
 				if v.flag.Hot {
-					state.Hot = `http://127.0.0.1:35729/bud/hot/` + page.Key + `.js`
+					// TODO: configurable
+					state.Hot = `http://127.0.0.1:35729/bud/hot?path=` + page.Path
 				}
 				code := new(bytes.Buffer)
 				if err := domEntryTemplate.Execute(code, state); err != nil {

--- a/package/viewer/svelte/svelte.go
+++ b/package/viewer/svelte/svelte.go
@@ -47,9 +47,9 @@ var _ viewer.Viewer = (*Viewer)(nil)
 func (v *Viewer) Mount(r *router.Router) error {
 	for _, page := range v.pages {
 		// Serve the entrypoints (for hydrating)
-		r.Get(page.Client, v.serveClientEntry(page))
+		r.Get(page.Client.Route, v.serveDOMEntry(page))
 		// Serve the individual views themselves (for hot reloads)
-		r.Get(page.View.Client, v.serveClientView(page.View))
+		r.Get(page.View.Client.Route, v.serveDOMView(page.View))
 	}
 	return nil
 }
@@ -60,21 +60,7 @@ func (v *Viewer) Render(ctx context.Context, key string, propMap viewer.PropMap)
 		return nil, fmt.Errorf("svelte: unable to find page from key %q", key)
 	}
 	v.log.Info("svelte: rendering", page.Path)
-	file, err := v.es.Serve(&es.Serve{
-		AbsDir:   v.module.Directory(),
-		Entry:    "./" + page.Path + ".js",
-		Platform: es.SSR,
-		Plugins: []es.Plugin{
-			v.ssrEntryPlugin(page),
-			v.ssrRuntimePlugin(),
-			v.ssrTranspile(ctx),
-			es.HTTP(http.DefaultClient),
-			es.ImportMap(v.log, map[string]string{
-				"svelte":  "https://esm.run/svelte@" + versions.Svelte,
-				"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
-			}),
-		},
-	})
+	file, err := v.compileSSR(ctx, page)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +68,6 @@ func (v *Viewer) Render(ctx context.Context, key string, propMap viewer.PropMap)
 	if err != nil {
 		return nil, err
 	}
-	// fmt.Println(string(file.Contents))
 	expr := fmt.Sprintf(`%s; bud.render(%s)`, string(file.Contents), propBytes)
 	html, err := v.js.Evaluate(ctx, page.Path, expr)
 	if err != nil {
@@ -104,21 +89,7 @@ func (v *Viewer) RenderError(ctx context.Context, key string, propMap viewer.Pro
 		return []byte(fmt.Sprintf("svelte: unable to find error page for %q to render error. %s", page.Error.Key, originalError))
 	}
 	v.log.Info("svelte: rendering error", errorPage.Path)
-	file, err := v.es.Serve(&es.Serve{
-		AbsDir:   v.module.Directory(),
-		Entry:    "./" + errorPage.Path + ".js",
-		Platform: es.SSR,
-		Plugins: []es.Plugin{
-			v.ssrEntryPlugin(errorPage),
-			v.ssrRuntimePlugin(),
-			v.ssrTranspile(ctx),
-			es.HTTP(http.DefaultClient),
-			es.ImportMap(v.log, map[string]string{
-				"svelte":  "https://esm.run/svelte@" + versions.Svelte,
-				"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
-			}),
-		},
-	})
+	file, err := v.compileSSR(ctx, errorPage)
 	if err != nil {
 		return []byte(fmt.Sprintf("svelte: unable to serve error page %q to render error. %s. %s", errorPage.Path, err, originalError))
 	}
@@ -135,8 +106,55 @@ func (v *Viewer) RenderError(ctx context.Context, key string, propMap viewer.Pro
 	return []byte(html)
 }
 
+func (v *Viewer) compileSSR(ctx context.Context, page *viewer.Page) (*es.File, error) {
+	return v.es.Serve(&es.Serve{
+		AbsDir:   v.module.Directory(),
+		Entry:    "./" + page.Path + ".js",
+		Platform: es.SSR,
+		Plugins: []es.Plugin{
+			v.ssrEntryPlugin(page),
+			v.ssrRuntimePlugin(),
+			v.ssrTranspile(ctx),
+			es.HTTP(http.DefaultClient),
+			es.ImportMap(v.log, map[string]string{
+				"svelte":  "https://esm.run/svelte@" + versions.Svelte,
+				"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
+			}),
+		},
+	})
+}
+
 func (v *Viewer) Bundle(ctx context.Context, embed virtual.Tree) error {
-	return fmt.Errorf("svelte: bundle not implemented")
+	for _, page := range v.pages {
+		file, err := v.compileSSR(ctx, page)
+		if err != nil {
+			return err
+		}
+		embed[page.Path] = &virtual.File{
+			Path: page.Path,
+			Mode: 0644,
+			Data: file.Contents,
+		}
+		file, err = v.compileDOMEntry(ctx, page)
+		if err != nil {
+			return err
+		}
+		embed[page.Client.Path] = &virtual.File{
+			Path: page.Client.Path,
+			Mode: 0644,
+			Data: file.Contents,
+		}
+		file, err = v.compileDOMView(ctx, page.View)
+		if err != nil {
+			return err
+		}
+		embed[page.View.Client.Path] = &virtual.File{
+			Path: page.View.Client.Path,
+			Mode: 0644,
+			Data: file.Contents,
+		}
+	}
+	return nil
 }
 
 // Handler serves the page as a static view
@@ -145,12 +163,12 @@ func (v *Viewer) Handler(page *viewer.Page) http.Handler {
 		ctx := r.Context()
 		propMap, err := viewer.StaticPropMap(page, r)
 		if err != nil {
-			v.handleError(ctx, w, page, propMap, err)
+			v.renderError(ctx, w, page, propMap, err)
 			return
 		}
 		html, err := v.Render(ctx, page.Key, propMap)
 		if err != nil {
-			v.handleError(ctx, w, page, propMap, err)
+			v.renderError(ctx, w, page, propMap, err)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -159,7 +177,7 @@ func (v *Viewer) Handler(page *viewer.Page) http.Handler {
 	})
 }
 
-func (v *Viewer) handleError(ctx context.Context, w http.ResponseWriter, page *viewer.Page, propMap map[string]interface{}, err error) {
+func (v *Viewer) renderError(ctx context.Context, w http.ResponseWriter, page *viewer.Page, propMap map[string]interface{}, err error) {
 	html := v.RenderError(ctx, page.Key, propMap, err)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusInternalServerError)
@@ -185,7 +203,7 @@ func (v *Viewer) ssrEntryPlugin(page *viewer.Page) es.Plugin {
 					Path      string
 					Key       string
 					Component string
-					Client    string
+					Client    *viewer.Client
 				}
 				type Page struct {
 					*View
@@ -300,26 +318,11 @@ func (v *Viewer) ssrTranspile(ctx context.Context) esbuild.Plugin {
 	}
 }
 
-// serveClient serves the entrypoints (for hydrating)
-func (v *Viewer) serveClientEntry(page *viewer.Page) http.Handler {
+// serveDOM serves the entrypoints (for hydrating)
+func (v *Viewer) serveDOMEntry(page *viewer.Page) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v.log.Info("svelte: serving client entry", r.URL.Path)
-		domJSCode, err := v.es.Serve(&es.Serve{
-			AbsDir:   v.module.Directory(),
-			Entry:    "./" + page.Path + ".js",
-			Platform: es.DOM,
-			Plugins: []es.Plugin{
-				v.domEntryPlugin(page),
-				v.domRuntimePlugin(),
-				v.domExternals(),
-				v.domTranspile(r.Context()),
-				es.ExternalHTTP(),
-				es.ExternalImportMap(v.log, map[string]string{
-					"svelte":  "https://esm.run/svelte@" + versions.Svelte,
-					"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
-				}),
-			},
-		})
+		domJSCode, err := v.compileDOMEntry(r.Context(), page)
 		if err != nil {
 			// TODO: hydrate a nice error message in the client
 			w.Header().Set("Content-Type", "text/plain")
@@ -333,23 +336,31 @@ func (v *Viewer) serveClientEntry(page *viewer.Page) http.Handler {
 	})
 }
 
-// serveClient serves the individual views themselves (for hot reloads)
-func (v *Viewer) serveClientView(view *viewer.View) http.Handler {
+// Compile DOM entrypoint
+func (v *Viewer) compileDOMEntry(ctx context.Context, page *viewer.Page) (*es.File, error) {
+	return v.es.Serve(&es.Serve{
+		AbsDir:   v.module.Directory(),
+		Entry:    "./" + page.Path + ".js",
+		Platform: es.DOM,
+		Plugins: []es.Plugin{
+			v.domEntryPlugin(page),
+			v.domRuntimePlugin(),
+			v.domExternals(),
+			v.domTranspile(ctx),
+			es.ExternalHTTP(),
+			es.ExternalImportMap(v.log, map[string]string{
+				"svelte":  "https://esm.run/svelte@" + versions.Svelte,
+				"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
+			}),
+		},
+	})
+}
+
+// serveDOM serves the individual views themselves (for hot reloads)
+func (v *Viewer) serveDOMView(view *viewer.View) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v.log.Info("svelte: serving client view", r.URL.Path)
-		domJsCode, err := v.es.Serve(&es.Serve{
-			AbsDir:   v.module.Directory(),
-			Entry:    "./" + view.Path,
-			Platform: es.DOM,
-			Plugins: []es.Plugin{
-				v.domTranspile(r.Context()),
-				es.ExternalHTTP(),
-				es.ExternalImportMap(v.log, map[string]string{
-					"svelte":  "https://esm.run/svelte@" + versions.Svelte,
-					"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
-				}),
-			},
-		})
+		domJsCode, err := v.compileDOMView(r.Context(), view)
 		if err != nil {
 			// TODO: hydrate a nice error message in the client
 			w.Header().Set("Content-Type", "text/plain")
@@ -360,6 +371,23 @@ func (v *Viewer) serveClientView(view *viewer.View) http.Handler {
 		w.Header().Set("Content-Type", "application/javascript")
 		w.WriteHeader(http.StatusOK)
 		w.Write(domJsCode.Contents)
+	})
+}
+
+// Compile DOM view
+func (v *Viewer) compileDOMView(ctx context.Context, view *viewer.View) (*es.File, error) {
+	return v.es.Serve(&es.Serve{
+		AbsDir:   v.module.Directory(),
+		Entry:    "./" + view.Path,
+		Platform: es.DOM,
+		Plugins: []es.Plugin{
+			v.domTranspile(ctx),
+			es.ExternalHTTP(),
+			es.ExternalImportMap(v.log, map[string]string{
+				"svelte":  "https://esm.run/svelte@" + versions.Svelte,
+				"svelte/": "https://esm.run/svelte@" + versions.Svelte + "/",
+			}),
+		},
 	})
 }
 
@@ -382,7 +410,6 @@ func (v *Viewer) domEntryPlugin(page *viewer.Page) es.Plugin {
 					Path      string
 					Key       string
 					Component string
-					Client    string
 				}
 				type Page struct {
 					*View
@@ -402,21 +429,21 @@ func (v *Viewer) domEntryPlugin(page *viewer.Page) es.Plugin {
 					View: &View{
 						Path:      page.Path,
 						Key:       page.Key,
-						Component: imports.AddNamed(gotext.Pascal(page.Key), path.Join("/view", page.Path+".js")),
+						Component: imports.AddNamed(gotext.Pascal(page.Key), page.View.Client.Route),
 					},
 				}
 				if page.Error != nil {
 					state.Page.Error = &View{
 						Path:      page.Error.Path,
 						Key:       page.Error.Key,
-						Component: imports.AddNamed(gotext.Pascal(page.Error.Key), path.Join("/view", page.Error.Path+".js")),
+						Component: imports.AddNamed(gotext.Pascal(page.Error.Key), page.Error.Client.Route),
 					}
 				}
 				for _, frame := range page.Frames {
 					state.Page.Frames = append(state.Page.Frames, &View{
 						Path:      frame.Path,
 						Key:       frame.Key,
-						Component: imports.AddNamed(gotext.Pascal(frame.Key), "/"+path.Join("view", frame.Path+".js")),
+						Component: imports.AddNamed(gotext.Pascal(frame.Key), frame.Client.Route),
 					})
 				}
 				state.Imports = imports.List()

--- a/package/viewer/svelte/svelte_test.go
+++ b/package/viewer/svelte/svelte_test.go
@@ -2,6 +2,7 @@ package svelte_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/livebud/bud/framework"
 	"github.com/livebud/bud/internal/is"
-	"github.com/livebud/bud/internal/versions"
 	"github.com/livebud/bud/package/es"
 	"github.com/livebud/bud/package/gomod"
 	"github.com/livebud/bud/package/log/testlog"
@@ -22,35 +22,28 @@ import (
 	"github.com/livebud/js/goja"
 )
 
-func TestPage(t *testing.T) {
-	is := is.New(t)
-	ctx := context.Background()
+func loadViewer(dir string) (*svelte.Viewer, error) {
 	log := testlog.New()
-	td, err := testdir.Load()
-	is.NoErr(err)
-	td.NodeModules["livebud"] = "*"
-	td.NodeModules["svelte"] = versions.Svelte
-	td.Files["index.svelte"] = `
-		<script>
-			export let planet = 'Mars'
-		</script>
-		<h1>Hello {planet}!</h1>
-	`
-	is.NoErr(td.Write(ctx))
-	module, err := gomod.Find(td.Directory())
-	is.NoErr(err)
+	module, err := gomod.Find(dir)
+	if err != nil {
+		return nil, err
+	}
 	pages, err := viewer.Find(module)
-	is.NoErr(err)
+	if err != nil {
+		return nil, err
+	}
 	js := goja.New(&js.Console{
 		Log:   os.Stdout,
 		Error: os.Stderr,
 	})
 	flag := &framework.Flag{}
-	esb := es.New(flag, log, module)
+	esb := es.New(flag, log)
 	svelteCompiler, err := svelte.Load(flag, js)
-	is.NoErr(err)
+	if err != nil {
+		return nil, err
+	}
 	tr := transpiler.New()
-	tr.Add(".svelte", ".ssr.js", func(file *transpiler.File) error {
+	tr.Add(".svelte", ".ssr.js", func(ctx context.Context, file *transpiler.File) error {
 		ssr, err := svelteCompiler.SSR(ctx, file.Path(), file.Data)
 		if err != nil {
 			return err
@@ -58,7 +51,7 @@ func TestPage(t *testing.T) {
 		file.Data = []byte(ssr.JS)
 		return nil
 	})
-	tr.Add(".svelte", ".dom.js", func(file *transpiler.File) error {
+	tr.Add(".svelte", ".dom.js", func(ctx context.Context, file *transpiler.File) error {
 		dom, err := svelteCompiler.DOM(ctx, file.Path(), file.Data)
 		if err != nil {
 			return err
@@ -67,6 +60,23 @@ func TestPage(t *testing.T) {
 		return nil
 	})
 	viewer := svelte.New(esb, flag, js, log, module, pages, tr)
+	return viewer, nil
+}
+
+func TestPage(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	td, err := testdir.Load()
+	is.NoErr(err)
+	td.Files["index.svelte"] = `
+		<script>
+			export let planet = 'Mars'
+		</script>
+		<h1>Hello {planet}!</h1>
+	`
+	is.NoErr(td.Write(ctx))
+	viewer, err := loadViewer(td.Directory())
+	is.NoErr(err)
 	html, err := viewer.Render(ctx, "index", map[string]interface{}{
 		"index": map[string]interface{}{
 			"planet": "Earth",
@@ -74,6 +84,8 @@ func TestPage(t *testing.T) {
 	})
 	is.NoErr(err)
 	is.Equal(string(html), `<h1>Hello Earth!</h1>`)
+
+	// Mount the client
 	router := router.New()
 	is.NoErr(viewer.Mount(router))
 
@@ -84,7 +96,7 @@ func TestPage(t *testing.T) {
 	res := rec.Result()
 	body, err := io.ReadAll(res.Body)
 	is.NoErr(err)
-	is.In(string(body), `"/node_modules/svelte/internal"`)
+	is.In(string(body), `"https://esm.run/svelte@3.47.0/internal"`)
 	is.In(string(body), `"/view/index.svelte.js"`)
 	is.In(string(body), `mount({`)
 	is.In(string(body), `key: "index"`)
@@ -97,18 +109,120 @@ func TestPage(t *testing.T) {
 	res = rec.Result()
 	body, err = io.ReadAll(res.Body)
 	is.NoErr(err)
-	is.In(string(body), `"/node_modules/svelte/internal"`)
+	is.In(string(body), `"https://esm.run/svelte@3.47.0/internal"`)
 	is.In(string(body), `"Hello "`)
 	is.In(string(body), `"planet"`)
 	is.Equal(res.StatusCode, 200)
 }
 
 func TestLayout(t *testing.T) {
-	t.Skip("TODO: test layouts")
+	is := is.New(t)
+	ctx := context.Background()
+	td, err := testdir.Load()
+	is.NoErr(err)
+	td.Files["show.svelte"] = `
+		<script>
+			export let planet = 'Mars'
+		</script>
+		<h1>Hello {planet}!</h1>
+	`
+	td.Files["layout.svelte"] = `
+		<script>
+			export let title = 'default'
+		</script>
+		<html>
+		<head>
+			<title>{title}</title>
+		</head>
+		<body>
+			<slot />
+		</body>
+		</html>
+	`
+	is.NoErr(td.Write(ctx))
+	viewer, err := loadViewer(td.Directory())
+	is.NoErr(err)
+	html, err := viewer.Render(ctx, "show", map[string]interface{}{
+		"layout": map[string]interface{}{
+			"title": "Hello",
+		},
+		"show": map[string]interface{}{
+			"planet": "Earth",
+		},
+	})
+	is.NoErr(err)
+	is.In(string(html), `<head><title>Hello</title></head>`)
+	is.In(string(html), `<script id="bud_state" type="text/template">{"props":{"show":{"planet":"Earth"}}}</script>`)
+	is.In(string(html), `<h1>Hello Earth!</h1>`)
+
+	// Mount the client
+	router := router.New()
+	is.NoErr(viewer.Mount(router))
+
+	// Entry
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/view/show.svelte.entry.js", nil)
+	router.ServeHTTP(rec, req)
+	res := rec.Result()
+	body, err := io.ReadAll(res.Body)
+	is.NoErr(err)
+	is.In(string(body), `"https://esm.run/svelte@3.47.0/internal"`)
+	is.In(string(body), `"/view/show.svelte.js"`)
+	is.In(string(body), `mount({`)
+	is.In(string(body), `key: "show"`)
+	is.Equal(res.StatusCode, 200)
+
+	// View
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/view/show.svelte.js", nil)
+	router.ServeHTTP(rec, req)
+	res = rec.Result()
+	body, err = io.ReadAll(res.Body)
+	is.NoErr(err)
+	is.In(string(body), `"https://esm.run/svelte@3.47.0/internal"`)
+	is.In(string(body), `"Hello "`)
+	is.In(string(body), `"planet"`)
+	is.Equal(res.StatusCode, 200)
+
+	// Shouldn't expose the layout
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/view/layout.svelte.js", nil)
+	router.ServeHTTP(rec, req)
+	res = rec.Result()
+	is.Equal(res.StatusCode, 404)
 }
 
 func TestRenderError(t *testing.T) {
-	t.Skip("TODO: test render error")
+	t.Skip("not done yet")
+	is := is.New(t)
+	ctx := context.Background()
+	td, err := testdir.Load()
+	is.NoErr(err)
+	td.Files["index.svelte"] = `
+		<script>
+			export let planet = 'Mars'
+		</script>
+		<h1>Hello {planet}!</h1>
+	`
+	td.Files["layout.svelte"] = `
+		<html><slot /></html>
+	`
+	td.Files["error.svelte"] = `
+		<script>
+			export let message = ''
+		</script>
+		<div class="error">{message}</div>
+	`
+	is.NoErr(td.Write(ctx))
+	viewer, err := loadViewer(td.Directory())
+	is.NoErr(err)
+	html := viewer.RenderError(ctx, "index", map[string]interface{}{
+		"index": map[string]interface{}{
+			"Planet": "Earth",
+		},
+	}, errors.New("some error"))
+	is.NoErr(err)
+	is.Equal(string(html), `<html><div class="error">some error</div></html>`)
 }
 
 func TestBundle(t *testing.T) {

--- a/package/viewer/viewer.go
+++ b/package/viewer/viewer.go
@@ -36,7 +36,7 @@ type View struct {
 	Key    Key
 	Path   string
 	Ext    string
-	Client string // View client
+	Client *Client // View client
 }
 
 type Page struct {
@@ -47,7 +47,12 @@ type Page struct {
 	Layout *View
 	Error  *View
 	Route  string
-	Client string // Entry client
+	Client *Client // Entry client
+}
+
+type Client struct {
+	Path  string
+	Route string
 }
 
 type Embed = virtual.File

--- a/scripts/svelte/error.svelte
+++ b/scripts/svelte/error.svelte
@@ -1,0 +1,11 @@
+<script>
+  export let message = ""
+</script>
+
+<svelte:head>
+  <title>Oh no!</title>
+</svelte:head>
+
+<h1>Oh no!</h1>
+
+<pre>{message}</pre>

--- a/scripts/svelte/index.svelte
+++ b/scripts/svelte/index.svelte
@@ -1,0 +1,9 @@
+<script>
+  import uid from "uid"
+  export let planet = "Mars"
+  let count = 0
+</script>
+
+<h1>Hello {planet}! {uid()}</h1>
+
+<button on:click={() => count++}>Total: {count}</button>

--- a/scripts/svelte/index.svelte
+++ b/scripts/svelte/index.svelte
@@ -1,9 +1,9 @@
 <script>
-  import uid from "uid"
+  // import uid from "uid"
   export let planet = "Mars"
   let count = 0
 </script>
 
-<h1>Hello {planet}! {uid()}</h1>
+<h1>Hello {planet}!</h1>
 
 <button on:click={() => count++}>Total: {count}</button>

--- a/scripts/svelte/layout.svelte
+++ b/scripts/svelte/layout.svelte
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <slot name="head" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/scripts/svelte/main.go
+++ b/scripts/svelte/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/livebud/bud/framework"
+	"github.com/livebud/bud/internal/current"
+	"github.com/livebud/bud/package/es"
+	"github.com/livebud/bud/package/gomod"
+	"github.com/livebud/bud/package/log"
+	"github.com/livebud/bud/package/log/console"
+	"github.com/livebud/bud/package/router"
+	"github.com/livebud/bud/package/transpiler"
+	"github.com/livebud/bud/package/viewer"
+	"github.com/livebud/bud/package/viewer/svelte"
+	"github.com/livebud/js"
+	"github.com/livebud/js/goja"
+)
+
+func main() {
+	if err := run(); err != nil {
+		console.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	dir, err := current.Directory()
+	if err != nil {
+		return err
+	}
+	log := log.New(console.New(os.Stderr))
+	module := gomod.New(dir)
+	pages, err := viewer.Find(module)
+	if err != nil {
+		return err
+	}
+	svelte, err := loadViewer(log, module, pages)
+	if err != nil {
+		return err
+	}
+	router := router.New()
+	if err := svelte.Mount(router); err != nil {
+		return err
+	}
+	for _, page := range pages {
+		router.Get(page.Route, svelte.Handler(page))
+	}
+
+	log.Info("listening on http://localhost:3000")
+	return http.ListenAndServe(":3000", router)
+}
+
+func loadViewer(log log.Log, module *gomod.Module, pages map[string]*viewer.Page) (*svelte.Viewer, error) {
+	js := goja.New(&js.Console{
+		Log:   os.Stdout,
+		Error: os.Stderr,
+	})
+	flag := &framework.Flag{}
+	esb := es.New(flag, log)
+	svelteCompiler, err := svelte.Load(flag, js)
+	if err != nil {
+		return nil, err
+	}
+	tr := transpiler.New()
+	tr.Add(".svelte", ".ssr.js", func(ctx context.Context, file *transpiler.File) error {
+		ssr, err := svelteCompiler.SSR(ctx, file.Path(), file.Data)
+		if err != nil {
+			return err
+		}
+		file.Data = []byte(ssr.JS)
+		return nil
+	})
+	tr.Add(".svelte", ".dom.js", func(ctx context.Context, file *transpiler.File) error {
+		dom, err := svelteCompiler.DOM(ctx, file.Path(), file.Data)
+		if err != nil {
+			return err
+		}
+		file.Data = []byte(dom.JS)
+		return nil
+	})
+	viewer := svelte.New(esb, flag, js, log, module, pages, tr)
+	return viewer, nil
+}

--- a/scripts/svelte/show.svelte
+++ b/scripts/svelte/show.svelte
@@ -1,0 +1,6 @@
+<script>
+  export let planet = "Mars"
+  export let id = 0
+</script>
+
+<h1>Hello {planet} from {id}!</h1>

--- a/scripts/svelte/show.svelte
+++ b/scripts/svelte/show.svelte
@@ -4,6 +4,6 @@
   export let count = 0
 </script>
 
-<h1>Hello {planet} from {id}!</h1>
+<h1>Hello {planet} from {id}</h1>
 
 <button on:click={() => count++}>Total: {count}</button>

--- a/scripts/svelte/show.svelte
+++ b/scripts/svelte/show.svelte
@@ -1,6 +1,9 @@
 <script>
   export let planet = "Mars"
   export let id = 0
+  export let count = 0
 </script>
 
 <h1>Hello {planet} from {id}!</h1>
+
+<button on:click={() => count++}>Total: {count}</button>


### PR DESCRIPTION
This PR is a bit of a smorgasbord of functionality. I'm trying to get error pages working in Svelte, but along the way, I started working on removing node_modules and also improve the UI of the errors. 

Going to commit this now since tests still pass and I need to make some changes to the viewer error struct.